### PR TITLE
Cache docker intermediate images for faster builds

### DIFF
--- a/.azure/build-linux-docker-images.yml
+++ b/.azure/build-linux-docker-images.yml
@@ -23,7 +23,7 @@ jobs:
 
       - task: CacheBeta@0
         inputs:
-          key: docker-cache-ci-vfx-v1 | ci-${{ img }}_${{ parameters.vfxplatform_version }}
+          key: docker-cache-ci-vfx-v1 | ci-${{ img }}_${{ parameters.vfxplatform_version }} | ci-${{ img }}/Dockerfile
           path: $(Pipeline.Workspace)/cache/${{ img }}_${{ parameters.vfxplatform_version }}
           cacheHitVar: CACHE_RESTORED
         displayName: Cache Docker history

--- a/.azure/build-linux-docker-images.yml
+++ b/.azure/build-linux-docker-images.yml
@@ -10,21 +10,25 @@ jobs:
 - ${{ each img in parameters.images }}:
   - job: build_${{ img }}_${{ parameters.vfxplatform_version }}
     displayName: Build ci-${{ img }}:${{ parameters.vfxplatform_version }}
+    dependsOn: build_common_docker_images
     timeoutInMinutes: 0
+    variables:
+      docker_build_date: $[ dependencies.build_common_docker_images.outputs['setVariables.out_docker_build_date'] ]
+      docker_vcs_ref: $[ dependencies.build_common_docker_images.outputs['setVariables.out_docker_vcs_ref'] ]
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
-      - bash: mkdir -p $(Pipeline.Workspace)/docker-cache/${{ img }}_${{ parameters.vfxplatform_version }}
+      - bash: mkdir -p $(Pipeline.Workspace)/cache/${{ img }}_${{ parameters.vfxplatform_version }}
         displayName: Prepare Docker Cache
 
       - task: CacheBeta@0
         inputs:
-          key: docker | ci-${{ img }}_${{ parameters.vfxplatform_version }}
-          path: $(Pipeline.Workspace)/docker-cache/${{ img }}_${{ parameters.vfxplatform_version }}
+          key: docker-cache-ci-vfx-v1 | ci-${{ img }}_${{ parameters.vfxplatform_version }}
+          path: $(Pipeline.Workspace)/cache/${{ img }}_${{ parameters.vfxplatform_version }}
           cacheHitVar: CACHE_RESTORED
         displayName: Cache Docker history
 
-      - bash: docker load < $(Pipeline.Workspace)/docker-cache/${{ img }}_${{ parameters.vfxplatform_version }}/cache.tar
+      - bash: docker load < $(Pipeline.Workspace)/cache/${{ img }}_${{ parameters.vfxplatform_version }}/cache.tar
         displayName: Load docker history from cache
         condition: eq(variables.CACHE_RESTORED, 'true')
 
@@ -39,7 +43,8 @@ jobs:
 
       - bash: |
           docker build . -t $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} -f ci-${{ img }}/Dockerfile \
-            $(docker_build_args) \
+            --build-arg BUILD_DATE=$(docker_build_date) \
+            --build-arg VCS_REF=$(docker_vcs_ref) \
             --build-arg ASWF_ORG=$(dockerhub.org) \
             --build-arg VFXPLATFORM_VERSION=${{ parameters.vfxplatform_version }} \
             --build-arg CI_COMMON_VERSION=${{ parameters.cicommon_version }} \
@@ -53,8 +58,9 @@ jobs:
         - bash: docker tag $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} $(dockerhub.org)/ci-${{ img }}:${{ tag }}
           displayName: Tag Docker Image with tag ${{ tag }}
 
-      - bash: docker save $(docker history -q $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/docker-cache/${{ img }}_${{ parameters.vfxplatform_version }}/cache.tar
+      - bash: docker save $(docker history -q $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/cache/${{ img }}_${{ parameters.vfxplatform_version }}/cache.tar
         displayName: Save Docker cache with history
+        condition: ne(variables.CACHE_RESTORED, 'true')
 
       - bash: |
           echo "$DOCKER_PASSWORD" | docker login -u $(dockerhub.username) --password-stdin

--- a/.azure/build-linux-docker-images.yml
+++ b/.azure/build-linux-docker-images.yml
@@ -14,21 +14,32 @@ jobs:
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
+      - bash: mkdir -p $(Pipeline.Workspace)/docker-cache/${{ img }}_${{ parameters.vfxplatform_version }}
+        displayName: Prepare Docker Cache
+
+      - task: CacheBeta@0
+        inputs:
+          key: docker | ci-${{ img }}_${{ parameters.vfxplatform_version }}
+          path: $(Pipeline.Workspace)/docker-cache/${{ img }}_${{ parameters.vfxplatform_version }}
+          cacheHitVar: CACHE_RESTORED
+        displayName: Cache Docker history
+
+      - bash: docker load < $(Pipeline.Workspace)/docker-cache/${{ img }}_${{ parameters.vfxplatform_version }}/cache.tar
+        displayName: Load docker history from cache
+        condition: eq(variables.CACHE_RESTORED, 'true')
+
       - download: current
         artifact: ci-common-image
         displayName: Download Docker cache artifact
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
       
-      - bash: |
-          gunzip -c $(Pipeline.Workspace)/ci-common-image/ci-common.tar.gz | docker load
-          rm -rf ci-common-image
+      - bash: gunzip -c $(Pipeline.Workspace)/ci-common-image/ci-common.tar.gz | docker load
         displayName: Load ci-common image from artifact
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
       - bash: |
           docker build . -t $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} -f ci-${{ img }}/Dockerfile \
-            --build-arg BUILD_DATE=`date -u +'%Y-%m-%dT%H:%M:%SZ'` \
-            --build-arg VCS_REF=`git rev-parse --short HEAD` \
+            $(docker_build_args) \
             --build-arg ASWF_ORG=$(dockerhub.org) \
             --build-arg VFXPLATFORM_VERSION=${{ parameters.vfxplatform_version }} \
             --build-arg CI_COMMON_VERSION=${{ parameters.cicommon_version }} \
@@ -41,6 +52,9 @@ jobs:
       - ${{ each tag in parameters.tags }}:
         - bash: docker tag $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} $(dockerhub.org)/ci-${{ img }}:${{ tag }}
           displayName: Tag Docker Image with tag ${{ tag }}
+
+      - bash: docker save $(docker history -q $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/docker-cache/${{ img }}_${{ parameters.vfxplatform_version }}/cache.tar
+        displayName: Save Docker cache with history
 
       - bash: |
           echo "$DOCKER_PASSWORD" | docker login -u $(dockerhub.username) --password-stdin

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 variables:
   - name: CI_COMMON_VERSION
     value: "1.0"
-  - group: dockerhub-staging
+  - group: dockerhub-release
 
 stages:
 - stage: build_common_docker_images

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
     
     - task: CacheBeta@0
       inputs:
-        key: docker-cache-ci-common-v1 | "ci-common-$(CI_COMMON_VERSION)"
+        key: docker-cache-ci-common-v1 | "ci-common-$(CI_COMMON_VERSION)" | ci-common/Dockerfile | scripts/common/*.sh
         path: $(Pipeline.Workspace)/cache/ci-common-$(CI_COMMON_VERSION)
         cacheHitVar: CACHE_RESTORED
       displayName: Cache Docker history

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,34 @@ stages:
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
-      - bash: docker build -t $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} -f ci-common/Dockerfile --build-arg CI_COMMON_VERSION=${CI_COMMON_VERSION} --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') .
+      - bash: |
+          echo '##vso[task.setvariable variable=docker_build_args;isOutput=true]--build-arg BUILD_DATE=`date -u +'%Y-%m-%dT%H:%M:%SZ'` --build-arg VCS_REF=`git rev-parse --short HEAD`'
+        displayName: Configure additional docker build args for master
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+
+      - bash: |
+          echo '##vso[task.setvariable variable=docker_build_args;isOutput=true]'
+        displayName: Configure additional docker build args for caching
+        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+
+      - bash: mkdir -p $(Pipeline.Workspace)/docker-cache/ci-common-$(CI_COMMON_VERSION)
+        displayName: Prepare Docker Cache
+      
+      - task: CacheBeta@0
+        inputs:
+          key: docker | "ci-common-$(CI_COMMON_VERSION)"
+          path: $(Pipeline.Workspace)/docker-cache/ci-common-$(CI_COMMON_VERSION)
+          cacheHitVar: CACHE_RESTORED
+        displayName: Cache Docker history
+
+      - bash: docker load < $(Pipeline.Workspace)/docker-cache/ci-common-${CI_COMMON_VERSION}/cache.tar
+        displayName: Load ci-common history from cache
+        condition: eq(variables.CACHE_RESTORED, 'true')
+
+      - bash: |
+          docker build . -t $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} -f ci-common/Dockerfile \
+            $(docker_build_args) \
+            --build-arg CI_COMMON_VERSION=${CI_COMMON_VERSION}
         displayName: Build Docker Images
 
       - bash: |
@@ -32,18 +59,21 @@ stages:
         env:
           DOCKER_PASSWORD: $(dockerhub.password)
 
+      - bash: docker save $(docker history -q $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/docker-cache/ci-common-${CI_COMMON_VERSION}/cache.tar
+        displayName: Save Docker cache with history
+
       - bash: docker save $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} | gzip -c > ci-common.tar.gz
         displayName: Save Docker Image
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
       - publish: ci-common.tar.gz
         artifact: ci-common-image
-        displayName: Publish Docker cache artifact
+        displayName: Publish Docker image artifact
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
 - stage: build_vfx_docker_images
   displayName: Build VFX Platform Docker Images
-  condition: always()
+  condition: succeeded('build_common_docker_images')
   jobs:
   - template: .azure/build-linux-docker-images.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,93 +11,96 @@ variables:
     value: "1.0"
   - group: dockerhub-release
 
-stages:
-- stage: build_common_docker_images
-  displayName: Build Common Docker Images
-  condition: always()
-  jobs:
-  - job:
-    timeoutInMinutes: 0
-    pool:
-      vmImage: 'ubuntu-16.04'
-    steps:
-      - bash: |
-          echo '##vso[task.setvariable variable=docker_build_args;isOutput=true]--build-arg BUILD_DATE=`date -u +'%Y-%m-%dT%H:%M:%SZ'` --build-arg VCS_REF=`git rev-parse --short HEAD`'
-        displayName: Configure additional docker build args for master
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+jobs:
+- job: build_common_docker_images
+  displayName: Build ci-common
+  timeoutInMinutes: 0
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - bash: |
+        echo '##vso[task.setvariable variable=docker_build_date]`date -u +\'%Y-%m-%dT%H:%M:%SZ\'`' && \
+        echo '##vso[task.setvariable variable=docker_vcs_ref]`git rev-parse --short HEAD`'
+      displayName: Configure additional docker variables for master
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
-      - bash: |
-          echo '##vso[task.setvariable variable=docker_build_args;isOutput=true]'
-        displayName: Configure additional docker build args for caching
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+    - bash: |
+        echo '##vso[task.setvariable variable=docker_build_date]dev' && \
+        echo '##vso[task.setvariable variable=docker_vcs_ref]dev'
+      displayName: Configure additional docker variables for caching
+      condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
-      - bash: mkdir -p $(Pipeline.Workspace)/docker-cache/ci-common-$(CI_COMMON_VERSION)
-        displayName: Prepare Docker Cache
-      
-      - task: CacheBeta@0
-        inputs:
-          key: docker | "ci-common-$(CI_COMMON_VERSION)"
-          path: $(Pipeline.Workspace)/docker-cache/ci-common-$(CI_COMMON_VERSION)
-          cacheHitVar: CACHE_RESTORED
-        displayName: Cache Docker history
+    - bash: |
+        echo '##vso[task.setvariable variable=out_docker_build_date;isOutput=true]$(docker_build_date)' && \
+        echo '##vso[task.setvariable variable=out_docker_vcs_ref;isOutput=true]$(docker_vcs_ref)'
+      displayName: Configure additional docker variables for downstream jobs
+      name: setVariables
 
-      - bash: docker load < $(Pipeline.Workspace)/docker-cache/ci-common-${CI_COMMON_VERSION}/cache.tar
-        displayName: Load ci-common history from cache
-        condition: eq(variables.CACHE_RESTORED, 'true')
+    - bash: mkdir -p $(Pipeline.Workspace)/cache/ci-common-$(CI_COMMON_VERSION)
+      displayName: Prepare Docker Cache
+    
+    - task: CacheBeta@0
+      inputs:
+        key: docker-cache-ci-common-v1 | "ci-common-$(CI_COMMON_VERSION)"
+        path: $(Pipeline.Workspace)/cache/ci-common-$(CI_COMMON_VERSION)
+        cacheHitVar: CACHE_RESTORED
+      displayName: Cache Docker history
 
-      - bash: |
-          docker build . -t $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} -f ci-common/Dockerfile \
-            $(docker_build_args) \
-            --build-arg CI_COMMON_VERSION=${CI_COMMON_VERSION}
-        displayName: Build Docker Images
+    - bash: docker load < $(Pipeline.Workspace)/cache/ci-common-${CI_COMMON_VERSION}/cache.tar
+      displayName: Load ci-common history from cache
+      condition: eq(variables.CACHE_RESTORED, 'true')
 
-      - bash: |
-          echo "$DOCKER_PASSWORD" | docker login -u $(dockerhub.username) --password-stdin
-          docker push $(dockerhub.org)/ci-common:${CI_COMMON_VERSION}
-        displayName: Docker login and push
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
-        env:
-          DOCKER_PASSWORD: $(dockerhub.password)
+    - bash: |
+        docker build . -t $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} -f ci-common/Dockerfile \
+          --build-arg BUILD_DATE=$(docker_build_date) \
+          --build-arg VCS_REF=$(docker_vcs_ref) \
+          --build-arg CI_COMMON_VERSION=${CI_COMMON_VERSION}
+      displayName: Build Docker Images
 
-      - bash: docker save $(docker history -q $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/docker-cache/ci-common-${CI_COMMON_VERSION}/cache.tar
-        displayName: Save Docker cache with history
+    - bash: |
+        echo "$DOCKER_PASSWORD" | docker login -u $(dockerhub.username) --password-stdin
+        docker push $(dockerhub.org)/ci-common:${CI_COMMON_VERSION}
+      displayName: Docker login and push
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      env:
+        DOCKER_PASSWORD: $(dockerhub.password)
 
-      - bash: docker save $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} | gzip -c > ci-common.tar.gz
-        displayName: Save Docker Image
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+    - bash: docker save $(docker history -q $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/cache/ci-common-${CI_COMMON_VERSION}/cache.tar
+      displayName: Save Docker cache with history
+      condition: ne(variables.CACHE_RESTORED, 'true')
 
-      - publish: ci-common.tar.gz
-        artifact: ci-common-image
-        displayName: Publish Docker image artifact
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+    - bash: docker save $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} | gzip -c > ci-common.tar.gz
+      displayName: Save Docker Image
+      condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
-- stage: build_vfx_docker_images
-  displayName: Build VFX Platform Docker Images
-  condition: succeeded('build_common_docker_images')
-  jobs:
-  - template: .azure/build-linux-docker-images.yml
-    parameters:
-      vfxplatform_version: '2018'
-      aswf_version: '2018.0'
-      python_version: '2.7'
-      cicommon_version: '1.0'
-      images: ['base', 'openexr', 'openvdb', 'ocio']
-      tags: ['2018']
+    - publish: ci-common.tar.gz
+      artifact: ci-common-image
+      displayName: Publish Docker image artifact
+      condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
-  - template: .azure/build-linux-docker-images.yml
-    parameters:
-      vfxplatform_version: '2019'
-      aswf_version: '2019.0'
-      python_version: '2.7'
-      cicommon_version: '1.0'
-      images: ['base', 'openexr', 'openvdb', 'ocio']
-      tags: ['2019', 'latest']
+- template: .azure/build-linux-docker-images.yml
+  parameters:
+    vfxplatform_version: '2018'
+    aswf_version: '2018.0'
+    python_version: '2.7'
+    cicommon_version: '1.0'
+    images: ['base', 'openexr', 'openvdb', 'ocio']
+    tags: ['2018']
 
-  - template: .azure/build-linux-docker-images.yml
-    parameters:
-      vfxplatform_version: '2020'
-      aswf_version: '2020.0'
-      python_version: '3.7'
-      cicommon_version: '1.0'
-      images: ['base', 'openexr']
-      tags: ['2020', 'draft']
+- template: .azure/build-linux-docker-images.yml
+  parameters:
+    vfxplatform_version: '2019'
+    aswf_version: '2019.0'
+    python_version: '2.7'
+    cicommon_version: '1.0'
+    images: ['base', 'openexr', 'openvdb', 'ocio']
+    tags: ['2019', 'latest']
+
+- template: .azure/build-linux-docker-images.yml
+  parameters:
+    vfxplatform_version: '2020'
+    aswf_version: '2020.0'
+    python_version: '3.7'
+    cicommon_version: '1.0'
+    images: ['base', 'openexr']
+    tags: ['2020', 'draft']

--- a/ci-common/Dockerfile
+++ b/ci-common/Dockerfile
@@ -1,9 +1,10 @@
 ARG CUDA_VERSION=10.1
 FROM nvidia/cudagl:${CUDA_VERSION}-devel-centos7
 
-ARG ASWF_ORG=aswfstaging
+ARG ASWF_ORG=aswf
 ARG BUILD_DATE=dev
 ARG VCS_REF=dev
+ARG CI_COMMON_VERSION=1.0
 
 LABEL maintainer="aloys.baillet@gmail.com"
 
@@ -100,7 +101,8 @@ RUN mkdir /opt/aswf
 WORKDIR /opt/aswf
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:${LD_LIBRARY_PATH} \
-    PATH=/usr/local/bin:/opt/rh/devtoolset-6/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-6/root/usr/bin/:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+    PATH=/usr/local/bin:/opt/rh/devtoolset-6/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-6/root/usr/bin/:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
+    CI_COMMON_VERSION=${CI_COMMON_VERSION}
 
 COPY scripts/common/*.sh \
      /tmp/


### PR DESCRIPTION
The main goal of this is to speed up feedback when working on PRs.

This brings the builds that can reuse the cache from 2 hours 45 minutes down to 30 minutes. This is still a long time but just restoring the docker cache takes around 5 minutes...
One other big gain would be to build clang and other bigger packages such as boost in separate jobs and then use pipeline artifacts to install them during the docker image build... Not sure it's worth tackling this problem without a package manager though.
 
As the caches are immutable, I had to use fairly precise cache keys (I've configured the CacheBeta task to use a hash of the Dockerfile and various scripts for ci-common). 
FYI the caches expire after 7 days, and each of the 11 jobs has its own 2.5Gb cache (expands to 5Gb of docker image data). 

I've also sneaked in a minor change which is to expose the CI_COMMON_VERSION as an environment variable in the ci-common image.