### PR TITLE
Fix system python and added yum wrapper

### DIFF
--- a/scripts/base/install_python.sh
+++ b/scripts/base/install_python.sh
@@ -2,30 +2,40 @@
 
 set -ex
 
+# Create script to allow use of system python
+cat <<EOF > /usr/local/bin/run-with-system-python
+#!/bin/sh
+# Unsets all environment variables so that the system python can function normally
+# To use, just prefix any command with run-with-system-python
+unset PYTHONPATH
+unset LIBRARY_PATH
+unset PKG_CONFIG_PATH
+export LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib
+export PATH=/opt/rh/devtoolset-6/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-6/root/usr/bin/:/usr/sbin:/usr/bin:/sbin:/bin
+exec "\$@"
+EOF
+chmod a+x /usr/local/bin/run-with-system-python
+
+# Create a yum wrapper that uses the system python
+cat <<EOF > /usr/local/bin/yum
+#!/bin/sh
+# This runs yum with system python
+exec /usr/local/bin/run-with-system-python /usr/bin/yum "\$@"
+EOF
+chmod a+x /usr/local/bin/yum
+
 curl --location https://www.python.org/ftp/python/${PYTHON_VERSION_FULL}/Python-${PYTHON_VERSION_FULL}.tgz -o Python.tgz
 tar xf Python.tgz && rm Python.tgz
 cd Python-${PYTHON_VERSION_FULL}
 
-PYTHONPATH_ORG=${PYTHONPATH}
-LIBRARY_PATH_ORG=${LIBRARY_PATH}
-PKG_CONFIG_PATH_ORG=${PKG_CONFIG_PATH}
-PATH_ORG=${PATH}
-LD_LIBRARY_PATH_ORG=${LD_LIBRARY_PATH}
-
-# Restore environment to default to ensure python installs correctly
-unset PYTHONPATH
-unset LIBRARY_PATH
-unset PKG_CONFIG_PATH
-export PATH=/opt/rh/devtoolset-6/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-6/root/usr/bin/:/usr/sbin:/usr/bin:/sbin:/bin
-export LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib
-
-./configure \
+# Ensure configure, build and install is done with no reference to /usr/local as this somehow messes up the system install
+run-with-system-python ./configure \
     --prefix=/usr/local \
     --enable-unicode=ucs4 \
     --enable-shared
-make -j4
+run-with-system-python make -j4
 
-sudo make altinstall
+run-with-system-python make altinstall
 
 if [[ $PYTHON_VERSION == 3* ]]; then
     # Create symlink from python3 to python
@@ -35,29 +45,11 @@ fi
 cd ..
 rm -rf Python-${PYTHON_VERSION_FULL}
 
-# Restore paths for pip to function
-export PYTHONPATH=${PYTHONPATH_ORG}
-export LIBRARY_PATH=${LIBRARY_PATH_ORG}
-export PKG_CONFIG_PATH=${PKG_CONFIG_PATH_ORG}
-export PATH=${PATH_ORG}
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ORG}
-
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" &&\
     python get-pip.py
 rm get-pip.py
 
 pip install \
     nose \
-    epydoc
-
-# Create script to restore original yum functionality
-cat <<EOF > /usr/local/bin/yum
-#!/bin/sh
-unset PYTHONPATH
-unset LIBRARY_PATH
-unset PKG_CONFIG_PATH
-unset LD_LIBRARY_PATH
-export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-exec /usr/bin/yum "\$@"
-EOF
-chmod a+x /usr/local/bin/yum
+    epydoc \
+    coverage

--- a/scripts/base/install_python.sh
+++ b/scripts/base/install_python.sh
@@ -6,25 +6,58 @@ curl --location https://www.python.org/ftp/python/${PYTHON_VERSION_FULL}/Python-
 tar xf Python.tgz && rm Python.tgz
 cd Python-${PYTHON_VERSION_FULL}
 
+PYTHONPATH_ORG=${PYTHONPATH}
+LIBRARY_PATH_ORG=${LIBRARY_PATH}
+PKG_CONFIG_PATH_ORG=${PKG_CONFIG_PATH}
+PATH_ORG=${PATH}
+LD_LIBRARY_PATH_ORG=${LD_LIBRARY_PATH}
+
+# Restore environment to default to ensure python installs correctly
+unset PYTHONPATH
+unset LIBRARY_PATH
+unset PKG_CONFIG_PATH
+export PATH=/opt/rh/devtoolset-6/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-6/root/usr/bin/:/usr/sbin:/usr/bin:/sbin:/bin
+export LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib
+
 ./configure \
     --prefix=/usr/local \
     --enable-unicode=ucs4 \
-    --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib"
+    --enable-shared
 make -j4
 
-sudo make install
+sudo make altinstall
 
 if [[ $PYTHON_VERSION == 3* ]]; then
     # Create symlink from python3 to python
-    ln -s /usr/local/bin/python3 /usr/local/bin/python
+    sudo ln -s /usr/local/bin/python3 /usr/local/bin/python
 fi
 
-cd ../..
+cd ..
 rm -rf Python-${PYTHON_VERSION_FULL}
+
+# Restore paths for pip to function
+export PYTHONPATH=${PYTHONPATH_ORG}
+export LIBRARY_PATH=${LIBRARY_PATH_ORG}
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH_ORG}
+export PATH=${PATH_ORG}
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ORG}
 
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" &&\
     python get-pip.py
+rm get-pip.py
 
 pip install \
     nose \
     epydoc
+
+# Create script to restore original yum functionality
+cat <<EOF > /usr/local/bin/yum
+#!/bin/sh
+unset PYTHONPATH
+unset LIBRARY_PATH
+unset PKG_CONFIG_PATH
+unset LD_LIBRARY_PATH
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+exec /usr/bin/yum "\$@"
+EOF
+chmod a+x /usr/local/bin/yum


### PR DESCRIPTION
This fixes #13 
The install_python.sh now also creates a `/usr/local/bin/yum` script that unsets the PYTHONPATH and PATH and LD_LIBRARY_PATH to ensure the normal python is used so yum can function normally.
This makes updating the `aswf/ci-*` images simple as one only need to run `sudo yum install ...` for additional packages.