### PR TITLE
Initial ci-opencue image.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ jobs:
     aswf_version: '2018.0'
     python_version: '2.7'
     cicommon_version: '1.0'
-    images: ['base', 'openexr', 'openvdb', 'ocio']
+    images: ['base', 'openexr', 'openvdb', 'ocio', 'opencue']
     tags: ['2018']
 
 - template: .azure/build-linux-docker-images.yml
@@ -93,7 +93,7 @@ jobs:
     aswf_version: '2019.0'
     python_version: '2.7'
     cicommon_version: '1.0'
-    images: ['base', 'openexr', 'openvdb', 'ocio']
+    images: ['base', 'openexr', 'openvdb', 'ocio', 'opencue']
     tags: ['2019', 'latest']
 
 - template: .azure/build-linux-docker-images.yml

--- a/ci-opencue/Dockerfile
+++ b/ci-opencue/Dockerfile
@@ -1,0 +1,53 @@
+ARG CI_COMMON_VERSION=1.0
+ARG ASWF_ORG=aswfstaging
+FROM ${ASWF_ORG}/ci-common:${CI_COMMON_VERSION}
+
+ARG VFXPLATFORM_VERSION=2019
+ARG BUILD_DATE=dev
+ARG VCS_REF=dev
+ARG PYTHON_VERSION=2.7
+
+LABEL maintainer="aloys.baillet@gmail.com"
+LABEL com.vfxplatform.version=$VFXPLATFORM_VERSION
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.name="$ASWF_ORG/base-opencue"
+LABEL org.label-schema.description="OpenCue CI Docker Image"
+LABEL org.label-schema.url="http://aswf.io/"
+LABEL org.label-schema.vcs-url="https://github.com/AcademySoftwareFoundation/aswf-docker"
+LABEL org.label-schema.vcs-ref=$VCS_REF
+LABEL org.label-schema.vendor="AcademySoftwareFoundation"
+LABEL org.label-schema.version=$VFXPLATFORM_VERSION
+LABEL org.label-schema.docker.cmd="docker run -v `pwd`:/tmp/project -it $ASWF_ORG/base-opencue bash"
+
+ENV PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:${PYTHONPATH} \
+    VFXPLATFORM_VERSION=$VFXPLATFORM_VERSION
+
+COPY scripts/$VFXPLATFORM_VERSION/versions_base.sh \
+     scripts/$VFXPLATFORM_VERSION/patchup.sh \
+     scripts/base/*.sh \
+     /tmp/
+
+RUN source /tmp/versions_base.sh && \
+    /tmp/install_python.sh && \
+    /tmp/patchup.sh
+
+COPY scripts/$VFXPLATFORM_VERSION/versions_vfx.sh \
+     scripts/vfx/*.sh \
+     /tmp/
+
+RUN source /tmp/versions_vfx.sh
+
+RUN yum -y install \
+    fontconfig \
+    freetype \
+    java-1.8.0-openjdk.x86_64 \
+    java-1.8.0-openjdk-devel.x86_64 \
+    libXi \
+    libXrender \
+    Xvfb
+
+# This is needed for Xvfb to function properly.
+RUN dbus-uuidgen > /etc/machine-id
+
+RUN pip install coverage

--- a/ci-opencue/Dockerfile
+++ b/ci-opencue/Dockerfile
@@ -50,4 +50,3 @@ RUN yum -y install \
 # This is needed for Xvfb to function properly.
 RUN dbus-uuidgen > /etc/machine-id
 
-RUN pip install coverage


### PR DESCRIPTION
I used the other projects' Dockerfiles as templates here -- they all seem to follow a fairly standard pattern so I stuck to that.

To start, add a few initial pieces for running OpenCue tests.

- JDK
- Xvfb (virtual X display to enable testing of GUI components)
- Python `coverage` tool for measuring unit test coverage.