### PR TITLE
Dynamically select the dockerhub org according to the branch name

### DIFF
--- a/.azure/build-linux-docker-images.yml
+++ b/.azure/build-linux-docker-images.yml
@@ -13,10 +13,10 @@ jobs:
     dependsOn: build_common_docker_images
     timeoutInMinutes: 0
     variables:
-      docker_build_date: $[ dependencies.build_common_docker_images.outputs['setVariables.out_docker_build_date'] ]
-      docker_vcs_ref: $[ dependencies.build_common_docker_images.outputs['setVariables.out_docker_vcs_ref'] ]
-      docker_org: $[ dependencies.build_common_docker_images.outputs['setVariables.out_docker_org'] ]
-      push_images: $[ dependencies.build_common_docker_images.outputs['setVariables.out_push_images'] ]
+      docker_build_date: $[ dependencies.build_common_docker_images.outputs['setVariables.docker_build_date'] ]
+      docker_vcs_ref: $[ dependencies.build_common_docker_images.outputs['setVariables.docker_vcs_ref'] ]
+      docker_org: $[ dependencies.build_common_docker_images.outputs['setVariables.docker_org'] ]
+      push_images: $[ dependencies.build_common_docker_images.outputs['setVariables.push_images'] ]
     pool:
       vmImage: 'ubuntu-16.04'
     steps:

--- a/.azure/build-linux-docker-images.yml
+++ b/.azure/build-linux-docker-images.yml
@@ -15,6 +15,8 @@ jobs:
     variables:
       docker_build_date: $[ dependencies.build_common_docker_images.outputs['setVariables.out_docker_build_date'] ]
       docker_vcs_ref: $[ dependencies.build_common_docker_images.outputs['setVariables.out_docker_vcs_ref'] ]
+      docker_org: $[ dependencies.build_common_docker_images.outputs['setVariables.out_docker_org'] ]
+      push_images: $[ dependencies.build_common_docker_images.outputs['setVariables.out_push_images'] ]
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -35,37 +37,42 @@ jobs:
       - download: current
         artifact: ci-common-image
         displayName: Download Docker cache artifact
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+        condition: eq(variables['push_images'], 'false')
       
       - bash: gunzip -c $(Pipeline.Workspace)/ci-common-image/ci-common.tar.gz | docker load
         displayName: Load ci-common image from artifact
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+        condition: eq(variables['push_images'], 'false')
 
       - bash: |
-          docker build . -t $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} -f ci-${{ img }}/Dockerfile \
+          docker build . -t $(docker_org)/ci-${{ img }}:${{ parameters.aswf_version }} -f ci-${{ img }}/Dockerfile \
             --build-arg BUILD_DATE=$(docker_build_date) \
             --build-arg VCS_REF=$(docker_vcs_ref) \
-            --build-arg ASWF_ORG=$(dockerhub.org) \
+            --build-arg ASWF_ORG=$(docker_org) \
             --build-arg VFXPLATFORM_VERSION=${{ parameters.vfxplatform_version }} \
             --build-arg CI_COMMON_VERSION=${{ parameters.cicommon_version }} \
             --build-arg PYTHON_VERSION=${{ parameters.python_version }}
         displayName: Build Docker Image
 
-      - bash: docker tag $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} $(dockerhub.org)/ci-${{ img }}:${{ parameters.vfxplatform_version }}
+      - bash: docker tag $(docker_org)/ci-${{ img }}:${{ parameters.aswf_version }} $(docker_org)/ci-${{ img }}:${{ parameters.vfxplatform_version }}
         displayName: Tag Docker Image with VFX Platform Version
       
       - ${{ each tag in parameters.tags }}:
-        - bash: docker tag $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} $(dockerhub.org)/ci-${{ img }}:${{ tag }}
+        - bash: docker tag $(docker_org)/ci-${{ img }}:${{ parameters.aswf_version }} $(docker_org)/ci-${{ img }}:${{ tag }}
           displayName: Tag Docker Image with tag ${{ tag }}
 
-      - bash: docker save $(docker history -q $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/cache/${{ img }}_${{ parameters.vfxplatform_version }}/cache.tar
+      - bash: docker save $(docker history -q $(docker_org)/ci-${{ img }}:${{ parameters.aswf_version }} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/cache/${{ img }}_${{ parameters.vfxplatform_version }}/cache.tar
         displayName: Save Docker cache with history
         condition: ne(variables.CACHE_RESTORED, 'true')
 
       - bash: |
           echo "$DOCKER_PASSWORD" | docker login -u $(dockerhub.username) --password-stdin
-          docker push $(dockerhub.org)/ci-${{ img }}:${{ parameters.aswf_version }}
+          docker push $(docker_org)/ci-${{ img }}:${{ parameters.aswf_version }}
         displayName: Docker login and push
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        condition: eq(variables['push_images'], 'true')
         env:
           DOCKER_PASSWORD: $(dockerhub.password)
+
+      - ${{ each tag in parameters.tags }}:
+        - bash: docker push $(docker_org)/ci-${{ img }}:${{ tag }}
+          displayName: Push Docker Image with tag ${{ tag }}
+          condition: eq(variables['push_images'], 'true')

--- a/.azure/configure_vars.sh
+++ b/.azure/configure_vars.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# This script outputs variables to be processed by the Azure Pipeline
+
+set -ex
+
+echo "Repo URI: $1"
+echo "Branch: $2"
+
+if [ $2 = refs/heads/master ] && [ $1 = https://github.com/AcademySoftwareFoundation/aswf-docker ]
+then
+    docker_build_date=`date -u +'%Y-%m-%dT%H:%M:%SZ'`
+    docker_vcs_ref=`git rev-parse --short HEAD`
+    docker_org=aswf
+    push_images=true
+elif [ $2 = refs/heads/staging ] && [ $1 = https://github.com/AcademySoftwareFoundation/aswf-docker ]
+then
+    docker_build_date=`date -u +'%Y-%m-%dT%H:%M:%SZ'`
+    docker_vcs_ref=`git rev-parse --short HEAD`
+    docker_org=aswfstaging
+    push_images=true
+elif [ $2 = refs/heads/testing ]
+then
+    docker_build_date=`date -u +'%Y-%m-%dT%H:%M:%SZ'`
+    docker_vcs_ref=`git rev-parse --short HEAD`
+    docker_org=aswftesting
+    push_images=true
+else
+    docker_build_date=dev
+    docker_vcs_ref=dev
+    docker_org=aswftesting
+    push_images=false
+fi
+
+# Output variables for current job
+echo "##vso[task.setvariable variable=docker_build_date]${docker_build_date}"
+echo "##vso[task.setvariable variable=docker_vcs_ref]${docker_vcs_ref}"
+echo "##vso[task.setvariable variable=docker_org]${docker_org}"
+echo "##vso[task.setvariable variable=push_images]${push_images}"
+
+# Output variables for downstream jobs
+echo "##vso[task.setvariable variable=docker_build_date;isOutput=true]${docker_build_date}"
+echo "##vso[task.setvariable variable=docker_vcs_ref;isOutput=true]${docker_vcs_ref}"
+echo "##vso[task.setvariable variable=docker_org;isOutput=true]${docker_org}"
+echo "##vso[task.setvariable variable=push_images;isOutput=true]${push_images}"

--- a/README.md
+++ b/README.md
@@ -31,5 +31,15 @@ The most precise version tag is the `ASWF_VERSION` of the image, e.g. `aswf/ci-b
 The `latest` tag is pointing to the current VFX Platorm year images, e.g. `aswf/ci-openexr:latest` points to `aswf/ci-openexr:2019.0` but will be updated to point to `aswf/ci-openexr:2020.0` in the calendar year 2020.
 
 
+## Staging and Testing
+
+There are two dockerhub organisations with copies of the `aswf` docker images:
+* `aswfstaging`: Images published there are for pre-release testing of specific features. Images can only be pushed to `aswfstaging` from the `staging` branch of the official `https://github.com/AcademySoftwareFoundation/aswf-docker` repository.
+* `aswftesting`: Images published there are for general testing and experimentations. Images can be pushed by any fork of the official repo as long as the branch is called `testing`. Images in this org will change without notice and could be broken in many unexpected ways! To get write access to the `aswftesting` dockerhub organisation you can open a jira issue [there](jira.aswf.io).
+
+The usual process would be to create PR against the `staging` branch of the repository. Once merged more testing can be done against the `aswfstaging` images (with a proper test suite on the roadmap).
+
+Once images on `aswfstaging` org are deemed stable then there would be a PR to master to trigger the generation of the official `aswf` images.
+
 ### Status
-As of June 2019 there are 2018 and 2019 VFX Platform. The 2020 version only contains base packages (such as python-3.7 and boost).
+As of September 2019 there are 2018 and 2019 VFX Platform. The 2020 version are experimental and mostly only contains base packages (such as python-3.7 and boost).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,21 +19,57 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
     - bash: |
-        echo "##vso[task.setvariable variable=docker_build_date]`date -u +'%Y-%m-%dT%H:%M:%SZ'`" && \
-        echo "##vso[task.setvariable variable=docker_vcs_ref]`git rev-parse --short HEAD`"
-      displayName: Configure additional docker variables for master
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        echo '##vso[task.setvariable variable=docker_build_date]`date -u +'%Y-%m-%dT%H:%M:%SZ'`'
+        echo '##vso[task.setvariable variable=docker_vcs_ref]`git rev-parse --short HEAD`'
+        echo '##vso[task.setvariable variable=docker_org]aswf'
+        echo '##vso[task.setvariable variable=push_images]true'
+      displayName: Configure additional docker variables for master on official repo
+      condition: |
+        and(
+          startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker'), 
+          eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        )
 
     - bash: |
-        echo '##vso[task.setvariable variable=docker_build_date]dev' && \
+        echo '##vso[task.setvariable variable=docker_build_date]`date -u +'%Y-%m-%dT%H:%M:%SZ'`'
+        echo '##vso[task.setvariable variable=docker_vcs_ref]`git rev-parse --short HEAD`'
+        echo '##vso[task.setvariable variable=docker_org]aswfstaging'
+        echo '##vso[task.setvariable variable=push_images]true'
+      displayName: Configure additional docker variables for staging on official repo
+      condition: |
+        and(
+          startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker'),
+          eq(variables['Build.SourceBranch'], 'refs/heads/staging')
+        )
+
+    - bash: |
+        echo '##vso[task.setvariable variable=docker_build_date]`date -u +'%Y-%m-%dT%H:%M:%SZ'`'
+        echo '##vso[task.setvariable variable=docker_vcs_ref]`git rev-parse --short HEAD`'
+        echo '##vso[task.setvariable variable=docker_org]aswfstaging'
+        echo '##vso[task.setvariable variable=push_images]true'
+      displayName: Configure additional docker variables for testing on any repo
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/testing')
+
+    - bash: |
+        echo '##vso[task.setvariable variable=docker_build_date]dev'
         echo '##vso[task.setvariable variable=docker_vcs_ref]dev'
-      displayName: Configure additional docker variables for caching
-      condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+        echo '##vso[task.setvariable variable=docker_org]aswftesting'
+        echo '##vso[task.setvariable variable=push_images]false'
+      displayName: Configure additional docker variables for normal jobs
+      condition: |
+        and(
+          not(startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker')),
+          ne(variables['Build.SourceBranch'], 'refs/heads/master'),
+          ne(variables['Build.SourceBranch'], 'refs/heads/staging'),
+          ne(variables['Build.SourceBranch'], 'refs/heads/testing')
+        )
 
     - bash: |
-        echo '##vso[task.setvariable variable=out_docker_build_date;isOutput=true]$(docker_build_date)' && \
+        echo '##vso[task.setvariable variable=out_docker_build_date;isOutput=true]$(docker_build_date)'
         echo '##vso[task.setvariable variable=out_docker_vcs_ref;isOutput=true]$(docker_vcs_ref)'
-      displayName: Configure additional docker variables for downstream jobs
+        echo '##vso[task.setvariable variable=out_docker_org;isOutput=true]$(docker_org)'
+        echo '##vso[task.setvariable variable=out_push_images;isOutput=true]$(push_images)'
+      displayName: Configure docker variables for downstream jobs
       name: setVariables
 
     - bash: mkdir -p $(Pipeline.Workspace)/cache/ci-common-$(CI_COMMON_VERSION)
@@ -51,7 +87,7 @@ jobs:
       condition: eq(variables.CACHE_RESTORED, 'true')
 
     - bash: |
-        docker build . -t $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} -f ci-common/Dockerfile \
+        docker build . -t $(docker_org)/ci-common:${CI_COMMON_VERSION} -f ci-common/Dockerfile \
           --build-arg BUILD_DATE=$(docker_build_date) \
           --build-arg VCS_REF=$(docker_vcs_ref) \
           --build-arg CI_COMMON_VERSION=${CI_COMMON_VERSION}
@@ -59,24 +95,24 @@ jobs:
 
     - bash: |
         echo "$DOCKER_PASSWORD" | docker login -u $(dockerhub.username) --password-stdin
-        docker push $(dockerhub.org)/ci-common:${CI_COMMON_VERSION}
+        docker push $(docker_org)/ci-common:${CI_COMMON_VERSION}
       displayName: Docker login and push
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      condition: eq(variables['push_images'], 'true')
       env:
         DOCKER_PASSWORD: $(dockerhub.password)
 
-    - bash: docker save $(docker history -q $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/cache/ci-common-${CI_COMMON_VERSION}/cache.tar
+    - bash: docker save $(docker history -q $(docker_org)/ci-common:${CI_COMMON_VERSION} | tr '\n' ' ' | tr -d '<missing>') > $(Pipeline.Workspace)/cache/ci-common-${CI_COMMON_VERSION}/cache.tar
       displayName: Save Docker cache with history
       condition: ne(variables.CACHE_RESTORED, 'true')
 
-    - bash: docker save $(dockerhub.org)/ci-common:${CI_COMMON_VERSION} | gzip -c > ci-common.tar.gz
+    - bash: docker save $(docker_org)/ci-common:${CI_COMMON_VERSION} | gzip -c > ci-common.tar.gz
       displayName: Save Docker Image
-      condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+      condition: eq(variables['push_images'], 'false')
 
     - publish: ci-common.tar.gz
       artifact: ci-common-image
-      displayName: Publish Docker image artifact
-      condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Publish Docker image artifact for downstream jobs
+      condition: eq(variables['push_images'], 'false')
 
 - template: .azure/build-linux-docker-images.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,12 +56,19 @@ jobs:
         echo '##vso[task.setvariable variable=docker_org]aswftesting'
         echo '##vso[task.setvariable variable=push_images]false'
       displayName: Configure additional docker variables for normal jobs
-      condition: |
-        and(
-          not(startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker')),
-          ne(variables['Build.SourceBranch'], 'refs/heads/master'),
-          ne(variables['Build.SourceBranch'], 'refs/heads/staging'),
-          ne(variables['Build.SourceBranch'], 'refs/heads/testing')
+      condition: | # This is the "else" of the 3 previous expressions...
+        not(
+            or(
+                and(
+                    startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker'), 
+                    eq(variables['Build.SourceBranch'], 'refs/heads/master')
+                ),
+                and(
+                    startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker'),
+                    eq(variables['Build.SourceBranch'], 'refs/heads/staging')
+                )
+                ,eq(variables['Build.SourceBranch'], 'refs/heads/testing')
+            )
         )
 
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,65 +18,8 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-    - bash: |
-        echo '##vso[task.setvariable variable=docker_build_date]`date -u +'%Y-%m-%dT%H:%M:%SZ'`'
-        echo '##vso[task.setvariable variable=docker_vcs_ref]`git rev-parse --short HEAD`'
-        echo '##vso[task.setvariable variable=docker_org]aswf'
-        echo '##vso[task.setvariable variable=push_images]true'
-      displayName: Configure additional docker variables for master on official repo
-      condition: |
-        and(
-          startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker'), 
-          eq(variables['Build.SourceBranch'], 'refs/heads/master')
-        )
-
-    - bash: |
-        echo '##vso[task.setvariable variable=docker_build_date]`date -u +'%Y-%m-%dT%H:%M:%SZ'`'
-        echo '##vso[task.setvariable variable=docker_vcs_ref]`git rev-parse --short HEAD`'
-        echo '##vso[task.setvariable variable=docker_org]aswfstaging'
-        echo '##vso[task.setvariable variable=push_images]true'
-      displayName: Configure additional docker variables for staging on official repo
-      condition: |
-        and(
-          startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker'),
-          eq(variables['Build.SourceBranch'], 'refs/heads/staging')
-        )
-
-    - bash: |
-        echo '##vso[task.setvariable variable=docker_build_date]`date -u +'%Y-%m-%dT%H:%M:%SZ'`'
-        echo '##vso[task.setvariable variable=docker_vcs_ref]`git rev-parse --short HEAD`'
-        echo '##vso[task.setvariable variable=docker_org]aswfstaging'
-        echo '##vso[task.setvariable variable=push_images]true'
-      displayName: Configure additional docker variables for testing on any repo
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/testing')
-
-    - bash: |
-        echo '##vso[task.setvariable variable=docker_build_date]dev'
-        echo '##vso[task.setvariable variable=docker_vcs_ref]dev'
-        echo '##vso[task.setvariable variable=docker_org]aswftesting'
-        echo '##vso[task.setvariable variable=push_images]false'
-      displayName: Configure additional docker variables for normal jobs
-      condition: | # This is the "else" of the 3 previous expressions...
-        not(
-            or(
-                and(
-                    startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker'), 
-                    eq(variables['Build.SourceBranch'], 'refs/heads/master')
-                ),
-                and(
-                    startsWith(variables['Build.Repository.Uri'], 'https://github.com/AcademySoftwareFoundation/aswf-docker'),
-                    eq(variables['Build.SourceBranch'], 'refs/heads/staging')
-                )
-                ,eq(variables['Build.SourceBranch'], 'refs/heads/testing')
-            )
-        )
-
-    - bash: |
-        echo '##vso[task.setvariable variable=out_docker_build_date;isOutput=true]$(docker_build_date)'
-        echo '##vso[task.setvariable variable=out_docker_vcs_ref;isOutput=true]$(docker_vcs_ref)'
-        echo '##vso[task.setvariable variable=out_docker_org;isOutput=true]$(docker_org)'
-        echo '##vso[task.setvariable variable=out_push_images;isOutput=true]$(push_images)'
-      displayName: Configure docker variables for downstream jobs
+    - bash: .azure/configure_vars.sh $(Build.Repository.Uri) $(Build.SourceBranch)
+      displayName: Configure docker variables according to branch and repo
       name: setVariables
 
     - bash: mkdir -p $(Pipeline.Workspace)/cache/ci-common-$(CI_COMMON_VERSION)


### PR DESCRIPTION
This will allow (with the use of the branch named "staging") to have a testing phase for the docker images.

I also fixed an issue with missing tags (every image tag has to be pushed independently) so `aswf/ci-base:2018` would not work, only `aswf/ci-base:2018.0` was valid. I manually merged this branch to a `testing` branch on my personal fork and all images were pushed properly to `aswftesting`.

Here is an excerpt of the update readme:

There are two dockerhub organisations with copies of the `aswf` docker images:
* `aswfstaging`: Images published there are for pre-release testing of specific features. Images can only be pushed to `aswfstaging` from the `staging` branch of the official `https://github.com/AcademySoftwareFoundation/aswf-docker` repository.
* `aswftesting`: Images published there are for general testing and experimentations. Images can be pushed by any fork of the official repo as long as the branch is called `testing`. Images in this org will change without notice and could be broken in many unexpected ways! To get write access to the `aswftesting` dockerhub organisation you can open a jira issue [there](jira.aswf.io).

The usual process would be to create PR against the `staging` branch of the repository. Once merged more testing can be done against the `aswfstaging` images (with a proper test suite on the roadmap).

Once images on `aswfstaging` org are deemed stable then there would be a PR to master to trigger the generation of the official `aswf` images.
