### PR TITLE
Enabled ci-opencue:2020

### DIFF
--- a/docker-bake-vfx-2020.hcl
+++ b/docker-bake-vfx-2020.hcl
@@ -3,7 +3,7 @@ group "default" {
 		"ci-openexr",
 		"ci-openvdb",
 		# "ci-ocio",
-		# "ci-opencue",
+		"ci-opencue",
 		# "ci-usd",
 		# "ci-vfxall",
 	]


### PR DESCRIPTION
Hi @bcipriano you should already be able to use `aswftesting/ci-opencue:2020` or `aswftesting/ci-opencue:2020.1` as I merge my branch into the `testing` branch on my fork. Happy to add you to `aswftesting` docker org if you want so you can experiment with it! Just send me your docker username.

Fixes #20 
