### PR TITLE
Split vfx image group to avoid space issues

### DIFF
--- a/.azure/build-linux-images.yml
+++ b/.azure/build-linux-images.yml
@@ -2,66 +2,67 @@ parameters:
   images: []
 
 jobs:
-- ${{ each img in parameters.images }}:
-  - job: build_${{ img.name }}_${{ img.version }}
-    displayName: Build ci-${{ img.name }}_${{ img.version }}
-    dependsOn: ${{ img.dependsOn }}
-    timeoutInMinutes: 0
-    condition: ${{ img.condition }}
-    variables:
-      DOCKER_CLI_EXPERIMENTAL: enabled
-      DOCKER_BUILDKIT: '1'
-    pool:
-      vmImage: 'ubuntu-18.04'
-    steps:
-      - template: prepare-docker.yml
-        parameters:
-          image_name: 'image_${{ img.name }}_${{ img.version }}'
-          cache_key_version: ${{ img.cache_key_version }}
-          cache_key_folder: ${{ img.scripts_folder }}
-          use_cacheable: 'false'
+- ${{ each group in parameters.groups }}:
+  - ${{ each group_version in group.versions }}:
+    - job: build_image_group_${{ group.name }}_${{ group_version }}
+      displayName: Build ci image group ${{ group.name }}:${{ group_version }}
+      condition: ${{ group.condition }}
+      dependsOn: ${{ group.dependsOn }}
+      timeoutInMinutes: 0
+      variables:
+        DOCKER_CLI_EXPERIMENTAL: enabled
+        DOCKER_BUILDKIT: '1'
+      pool:
+        vmImage: 'ubuntu-18.04'
+      steps:
+        - template: prepare-docker.yml
+          parameters:
+            image_name: 'image_${{ group.name }}_${{ group_version }}'
+            cache_key_version: ${{ group.cache_key_version }}
+            cache_key_folder: ${{ group.scripts_folder }}
+            use_cacheable: 'false'
 
-      - bash: |
-          set -ex
-          if [ "`aswfdocker getdockerpush`" != "true" ]
-          then
+        - bash: |
+            set -ex
+            if [ "`aswfdocker getdockerpush`" != "true" ]
+            then
+              aswfdocker \
+                --repo-uri $(Build.Repository.Uri) \
+                --source-branch $(Build.SourceBranch) \
+                --verbose \
+                build \
+                --ci-image-type IMAGE \
+                --group-name common \
+                --group-version 1
+            fi
+          displayName: Optionally build local ci-common Docker Image
+          condition: ne('${{ group.name }}', 'common')
+
+        - bash: |
+            set -ex
             aswfdocker \
               --repo-uri $(Build.Repository.Uri) \
               --source-branch $(Build.SourceBranch) \
               --verbose \
               build \
               --ci-image-type IMAGE \
-              --group-name common \
-              --group-version 1
-          fi
-        displayName: Optionally build local ci-common Docker Image
-        condition: ne('${{ img.name }}', 'common')
+              --group-name ${{ group.name }} \
+              --group-version ${{ group_version }} \
+          displayName: Build Docker Images
 
-      - bash: |
-          set -ex
-          aswfdocker \
-            --repo-uri $(Build.Repository.Uri) \
-            --source-branch $(Build.SourceBranch) \
-            --verbose \
-            build \
-            --ci-image-type IMAGE \
-            --group-name ${{ img.name }} \
-            --group-version ${{ img.version }} \
-        displayName: Build Docker Images
-
-      - ${{ each test in img.tests }}:
-        - bash: |
-            set -ex
-            export DOCKER_ORG=`aswfdocker --repo-uri $(Build.Repository.Uri) --source-branch $(Build.SourceBranch) getdockerorg`
-            test_script=scripts/tests/${{ img.version }}/test_${{ test }}.sh
-            if [ -f $test_script ]
-            then
-              echo "Going to run ${test_script}"
-              echo "docker run -i --rm ${DOCKER_ORG}/ci-${{ test }}:${{ img.version }} bash < ${test_script}"
-              docker run -i --rm \
-                -v $(Pipeline.Workspace)/cache/ci-image_${{ img.name }}_${{ img.version }}/ccache:/tmp/ccache \
-                ${DOCKER_ORG}/ci-${{ test }}:${{ img.version }} bash < ${test_script}
-            else
-              echo "No test script found $test_script"
-            fi
-          displayName: Run test script ${{ img.version }}/test_${{ test }}.sh to check docker image
+        - ${{ each test in group.tests }}:
+          - bash: |
+              set -ex
+              export DOCKER_ORG=`aswfdocker --repo-uri $(Build.Repository.Uri) --source-branch $(Build.SourceBranch) getdockerorg`
+              test_script=scripts/tests/${{ group_version }}/test_${{ test }}.sh
+              if [ -f $test_script ]
+              then
+                echo "Going to run ${test_script}"
+                echo "docker run -i --rm ${DOCKER_ORG}/ci-${{ test }}:${{ group_version }} bash < ${test_script}"
+                docker run -i --rm \
+                  -v $(Pipeline.Workspace)/cache/ci-image_${{ group.name }}_${{ group_version }}/ccache:/tmp/ccache \
+                  ${DOCKER_ORG}/ci-${{ test }}:${{ group_version }} bash < ${test_script}
+              else
+                echo "No test script found $test_script"
+              fi
+            displayName: Run test script ${{ group_version }}/test_${{ test }}.sh to check docker image

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Docker Images for the Academy Software Foundation
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) ![pytest coverage](https://img.shields.io/azure-devops/coverage/academysoftwarefoundation/Academy%20Software%20Foundation/2/master)
 
 | Docker Images | Build Status |
 | ---:         |     :---      |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,5 +209,4 @@ jobs:
             in(dependencies.build_package_group_baseqt_2020.result, 'Succeeded', 'Skipped'),
             in(dependencies.build_package_group_vfx_2020.result, 'Succeeded', 'Skipped')
           )
-        tests:
-          - openvdb
+        tests: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,10 +125,10 @@ jobs:
 
 - template: .azure/build-linux-images.yml
   parameters:
-    images:
+    groups:
       -
         name: common
-        version: '1'
+        versions: ['1']
         scripts_folder: 'common'
         cache_key_version: "4.11"
         dependsOn: 
@@ -138,40 +138,18 @@ jobs:
           - common
       -
         name: base
-        version: '2018'
+        versions: ['2018', '2019', '2020']
         scripts_folder: '**'
         cache_key_version: "4.11"
         dependsOn: 
           - build_package_group_common_1
-          - build_common_1
+          - build_image_group_common_1
         condition: in(dependencies.build_package_group_common_1.result, 'Succeeded', 'Skipped')
         tests:
           - base
       -
-        name: base
-        version: '2019'
-        scripts_folder: '**'
-        cache_key_version: "4.11"
-        dependsOn: 
-          - build_package_group_common_1
-          - build_common_1
-        condition: in(dependencies.build_package_group_common_1.result, 'Succeeded', 'Skipped')
-        tests:
-          - base
-      -
-        name: base
-        version: '2020'
-        scripts_folder: '**'
-        cache_key_version: "4.11"
-        dependsOn: 
-          - build_package_group_common_1
-          - build_common_1
-        condition: in(dependencies.build_package_group_common_1.result, 'Succeeded', 'Skipped')
-        tests:
-          - base
-      -
-        name: vfx
-        version: '2018'
+        name: vfx1
+        versions: ['2018', '2019', '2020']
         scripts_folder: '**'
         cache_key_version: "4.11"
         dependsOn: 
@@ -179,52 +157,57 @@ jobs:
           - build_package_group_base_2018
           - build_package_group_baseqt_2018
           - build_package_group_vfx_2018
-          - build_common_1
+          - build_package_group_base_2019
+          - build_package_group_baseqt_2019
+          - build_package_group_vfx_2019
+          - build_package_group_base_2020
+          - build_package_group_baseqt_2020
+          - build_package_group_vfx_2020
+          - build_image_group_common_1
         condition: |
           and(
             in(dependencies.build_package_group_common_1.result, 'Succeeded', 'Skipped'),
             in(dependencies.build_package_group_base_2018.result, 'Succeeded', 'Skipped'),
             in(dependencies.build_package_group_baseqt_2018.result, 'Succeeded', 'Skipped'),
-            in(dependencies.build_package_group_vfx_2018.result, 'Succeeded', 'Skipped')
-          )
-        tests:
-          - openvdb
-      -
-        name: vfx
-        version: '2019'
-        scripts_folder: '**'
-        cache_key_version: "4.11"
-        dependsOn: 
-          - build_package_group_common_1
-          - build_package_group_base_2019
-          - build_package_group_baseqt_2019
-          - build_package_group_vfx_2019
-          - build_common_1
-        condition: |
-          and(
-            in(dependencies.build_package_group_common_1.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_vfx_2018.result, 'Succeeded', 'Skipped'),
             in(dependencies.build_package_group_base_2019.result, 'Succeeded', 'Skipped'),
             in(dependencies.build_package_group_baseqt_2019.result, 'Succeeded', 'Skipped'),
-            in(dependencies.build_package_group_vfx_2019.result, 'Succeeded', 'Skipped')
-          )
-        tests:
-          - openvdb
-      -
-        name: vfx
-        version: '2020'
-        scripts_folder: '**'
-        cache_key_version: "4.11"
-        dependsOn: 
-          - build_package_group_common_1
-          - build_package_group_base_2020
-          - build_package_group_baseqt_2020
-          - build_package_group_vfx_2020
-          - build_common_1
-        condition: |
-          and(
-            in(dependencies.build_package_group_common_1.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_vfx_2019.result, 'Succeeded', 'Skipped'),
             in(dependencies.build_package_group_base_2020.result, 'Succeeded', 'Skipped'),
             in(dependencies.build_package_group_baseqt_2020.result, 'Succeeded', 'Skipped'),
             in(dependencies.build_package_group_vfx_2020.result, 'Succeeded', 'Skipped')
           )
-        tests: []
+        tests:
+          - openvdb
+      -
+        name: vfx2
+        versions: ['2018', '2019', '2020']
+        scripts_folder: '**'
+        cache_key_version: "4.11"
+        dependsOn: 
+          - build_package_group_common_1
+          - build_package_group_base_2018
+          - build_package_group_baseqt_2018
+          - build_package_group_vfx_2018
+          - build_package_group_base_2019
+          - build_package_group_baseqt_2019
+          - build_package_group_vfx_2019
+          - build_package_group_base_2020
+          - build_package_group_baseqt_2020
+          - build_package_group_vfx_2020
+          - build_image_group_common_1
+        condition: |
+          and(
+            in(dependencies.build_package_group_common_1.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_base_2018.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_baseqt_2018.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_vfx_2018.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_base_2019.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_baseqt_2019.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_vfx_2019.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_base_2020.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_baseqt_2020.result, 'Succeeded', 'Skipped'),
+            in(dependencies.build_package_group_vfx_2020.result, 'Succeeded', 'Skipped')
+          )
+        tests:
+          - openvdb

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,5 @@
 # ASWF Python Utilities
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) ![Azure DevOps coverage (branch)](https://img.shields.io/azure-devops/coverage/aloysbaillet/ASWF/4/add-migrate-script)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) ![pytest coverage](https://img.shields.io/azure-devops/coverage/academysoftwarefoundation/Academy%20Software%20Foundation/2/master)
 
 The `aswfdocker` command line tool is available to help with package and image builds.
 

--- a/python/aswfdocker/constants.py
+++ b/python/aswfdocker/constants.py
@@ -67,7 +67,8 @@ GROUPS = {
     ImageType.IMAGE: {
         "common": ["common"],
         "base": ["base"],
-        "vfx": ["openexr", "openvdb", "ocio", "opencue", "usd", "vfxall"],
+        "vfx1": ["openexr", "openvdb", "ocio"],
+        "vfx2": ["opencue", "usd", "vfxall"],
     },
 }
 

--- a/python/aswfdocker/utils.py
+++ b/python/aswfdocker/utils.py
@@ -10,11 +10,15 @@ from aswfdocker import constants
 
 
 def get_current_branch() -> str:
-    return subprocess.check_output("git rev-parse --abbrev-ref HEAD", encoding="UTF-8")
+    return subprocess.check_output(
+        "git rev-parse --abbrev-ref HEAD", encoding="UTF-8", shell=True
+    )
 
 
 def get_current_sha() -> str:
-    return subprocess.check_output("git rev-parse --short HEAD", encoding="UTF-8")
+    return subprocess.check_output(
+        "git rev-parse --short HEAD", encoding="UTF-8", shell=True
+    )
 
 
 def get_current_date() -> str:


### PR DESCRIPTION
Jobs were failing on master because they were running out of space, so I split the `vfx` image group into `vfx1` and `vfx2`. I also cleaned up some azure yaml config to have less duplication and the build-images and build-packages config look a lot more similar now.
I also updated the code coverage badge urls to point to the main repo on master.
And finally I fixed a mistake when detecting the current branch in `utils.py`.