### PR TITLE
Update git version to 2.22 in the ci-common image

### DIFF
--- a/scripts/common/install_yumpackages.sh
+++ b/scripts/common/install_yumpackages.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 set -ex
+#Installing Git Version 2.22
+yum install -y http://opensource.wandisco.com/centos/7/git/x86_64/git-2.22.0-1.WANdisco.437.x86_64.rpm
+yum install -y git
 
 yum install -y \
     alsa-lib alsa-lib-devel \
@@ -22,7 +25,6 @@ yum install -y \
     freetype freetype-devel \
     frei0r-devel \
     gdbm-devel \
-    git \
     glib2-devel \
     glut-devel \
     glx-utils \


### PR DESCRIPTION
In the docker image, for installing Git, I've used WANDisco's repository to ensure that the version of Git installed is v2.22.

This PR will fix #30 