### PR TITLE
Create non-root user for build steps that require it.

### DIFF
--- a/ci-opencue/Dockerfile
+++ b/ci-opencue/Dockerfile
@@ -51,3 +51,6 @@ RUN export DOWNLOADS_DIR=/tmp/downloads && \
 RUN yum -y install \
     java-1.8.0-openjdk.x86_64 \
     java-1.8.0-openjdk-devel.x86_64
+
+# Non-root user to be used for build steps that require it.
+RUN adduser builduser


### PR DESCRIPTION
Some of our build steps require running as a non-root user. DevOps creates a non-root user by default but Github Actions does not, when using a Docker image.

Adding the user here will save us a step in any CI jobs that require it.