### PR TITLE
Fixed missing tags in migrater

### DIFF
--- a/python/aswfdocker/migrater.py
+++ b/python/aswfdocker/migrater.py
@@ -52,6 +52,7 @@ class Migrater:
 
             self.cmds.append(f"docker pull {minfo.source}")
             self.cmds.append(f"docker tag {minfo.source} {minfo.destination}")
+            self.cmds.append(f"docker push {minfo.destination}")
 
             major_version = utils.get_major_version(minfo.version)
             version_info = constants.VERSION_INFO[major_version]
@@ -60,8 +61,7 @@ class Migrater:
                 for tag in tags:
                     if tag != minfo.destination:
                         self.cmds.append(f"docker tag {minfo.destination} {tag}")
-
-            self.cmds.append(f"docker push {minfo.destination}")
+                        self.cmds.append(f"docker push {tag}")
 
         if logger.isEnabledFor(logging.DEBUG):
             list(map(logger.debug, self.cmds))

--- a/python/aswfdocker/tests/test_migrater.py
+++ b/python/aswfdocker/tests/test_migrater.py
@@ -48,9 +48,11 @@ class TestMigrater(unittest.TestCase):
             [
                 f"docker pull {constants.DOCKER_REGISTRY}/src/ci-package-openexr:{current_version}",
                 f"docker tag {constants.DOCKER_REGISTRY}/src/ci-package-openexr:{current_version} {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:{current_version}",
-                f"docker tag {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:{current_version} {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:2019",
-                f"docker tag {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:{current_version} {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:latest",
                 f"docker push {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:{current_version}",
+                f"docker tag {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:{current_version} {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:2019",
+                f"docker push {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:2019",
+                f"docker tag {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:{current_version} {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:latest",
+                f"docker push {constants.DOCKER_REGISTRY}/dst/ci-package-openexr:latest",
             ],
         )
 


### PR DESCRIPTION
I used this script yesterday to migrate the new 2020 packages and noticed I was missing a few tags...