### PR TITLE
Upgrade Git.

### DIFF
--- a/ci-common/Dockerfile
+++ b/ci-common/Dockerfile
@@ -61,3 +61,7 @@ RUN export DOWNLOADS_DIR=/tmp/downloads && \
 
 COPY scripts/common/setup_aswfuser.sh /tmp
 RUN /tmp/setup_aswfuser.sh
+
+# Make Git 2.x the default version.
+RUN echo "source scl_source enable rh-git218" > /etc/profile.d/git-scl.sh
+

--- a/ci-opencue/Dockerfile
+++ b/ci-opencue/Dockerfile
@@ -47,3 +47,7 @@ RUN export DOWNLOADS_DIR=/tmp/downloads && \
 RUN yum -y install \
     java-1.8.0-openjdk.x86_64 \
     java-1.8.0-openjdk-devel.x86_64
+
+RUN yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm && \
+    yum -y install git
+

--- a/ci-opencue/Dockerfile
+++ b/ci-opencue/Dockerfile
@@ -47,4 +47,3 @@ RUN export DOWNLOADS_DIR=/tmp/downloads && \
 RUN yum -y install \
     java-1.8.0-openjdk.x86_64 \
     java-1.8.0-openjdk-devel.x86_64
-

--- a/ci-opencue/Dockerfile
+++ b/ci-opencue/Dockerfile
@@ -48,6 +48,3 @@ RUN yum -y install \
     java-1.8.0-openjdk.x86_64 \
     java-1.8.0-openjdk-devel.x86_64
 
-RUN yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm && \
-    yum -y install git
-

--- a/scripts/common/install_yumpackages.sh
+++ b/scripts/common/install_yumpackages.sh
@@ -24,7 +24,6 @@ yum install --setopt=tsflags=nodocs -y \
     frei0r-devel \
     gdbm-devel \
     giflib-devel \
-    git \
     glib2-devel \
     glut-devel \
     glx-utils \
@@ -128,6 +127,7 @@ yum install -y epel-release
 
 # Additional package that are not found initially
 yum install -y \
+    rh-git218 \
     lame-devel \
     libcaca-devel \
     libdb4-devel \

--- a/scripts/tests/1/test_common.sh
+++ b/scripts/tests/1/test_common.sh
@@ -21,3 +21,10 @@ if [[ $ninja_v != 1.* ]]
 then
     exit 1
 fi
+
+git_v=`git --version`
+if [[ $git_v != 2.* ]]
+then
+    exit 1
+fi
+

--- a/scripts/tests/2/test_common.sh
+++ b/scripts/tests/2/test_common.sh
@@ -21,3 +21,10 @@ if [[ $ninja_v != 1.* ]]
 then
     exit 1
 fi
+
+git_v=`git --version`
+if [[ $git_v != 2.* ]]
+then
+    exit 1
+fi
+


### PR DESCRIPTION
Github Actions [has a limitation](https://github.com/actions/checkout/issues/126): the `checkout` action does not leave a functional Git repository within the Docker container if you're using a `1.x` Git release.

Upgrading to a more recent Git `2.x` release fixes this.

Couple points to consider:
- Hard-coding that yum repo's URL seems bad -- is there a more future-proof way to do this?
- Are other ASWF projects hitting this problem? Should we consider merging this into the upstream image?

