### PR TITLE
Change git path

### DIFF
--- a/ci-common/Dockerfile
+++ b/ci-common/Dockerfile
@@ -38,9 +38,11 @@ RUN mkdir /opt/aswf
 WORKDIR /opt/aswf
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/lib64:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/lib:${LD_LIBRARY_PATH} \
-    PATH=/usr/local/bin:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin/:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PATH=/opt/rh/rh-git218/root/usr/bin:/usr/local/bin:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin/:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
     CI_COMMON_VERSION=${CI_COMMON_VERSION} \
-    DTS_VERSION=${DTS_VERSION}
+    DTS_VERSION=${DTS_VERSION} \
+    PERL5LIB=/opt/rh/rh-git218/root/usr/share/perl5/vendor_perl \
+    MANPATH=/opt/rh/rh-git218/root/usr/share/man
 
 COPY scripts/common/install_sonar.sh \
      scripts/common/install_ccache.sh \
@@ -61,7 +63,3 @@ RUN export DOWNLOADS_DIR=/tmp/downloads && \
 
 COPY scripts/common/setup_aswfuser.sh /tmp
 RUN /tmp/setup_aswfuser.sh
-
-# Make Git 2.x the default version.
-RUN echo "source scl_source enable rh-git218" > /etc/profile.d/git-scl.sh
-

--- a/scripts/common/install_yumpackages.sh
+++ b/scripts/common/install_yumpackages.sh
@@ -135,23 +135,3 @@ yum install -y \
     p7zip \
     yasm-devel \
     zvbi-devel
-
-if [[ $DTS_VERSION == 9 ]]; then
-    gcc_v=`/opt/rh/devtoolset-9/root/usr/bin/gcc --version`
-    if [[ $gcc_v == gcc\ \(GCC\)\ 9.1* ]]; then
-        # Use these temp yum packages to update to GCC-9.3.1
-        # @TODO remove when new sclo for devtoolset-9.1 is ready
-        yum install -y --setopt=tsflags=nodocs \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-gcc-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-gcc-c++-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-gcc-gdb-plugin-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-gcc-gfortran-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-gcc-plugin-devel-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-libgccjit-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-libgccjit-devel-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-libgccjit-docs-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-libitm-devel-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-libquadmath-devel-9.3.1-2.el7.x86_64.rpm \
-            https://cbs.centos.org/kojifiles/packages/devtoolset-9-gcc/9.3.1/2.el7/x86_64/devtoolset-9-libstdc++-devel-9.3.1-2.el7.x86_64.rpm
-    fi
-fi


### PR DESCRIPTION
This changes how git is found in the PATH, it should help GitHub actions find the right version of git.
Unfortunately it's not possible to install the IUS version of git as it conflicts with the currently installed version, and bypassing git in the `yum groupinstall "development tools"` means loosing the `gettext-devel` package...

Also removed now-obsolete install of devtoolset-9.1 as that's now the current version.