### PR TITLE
Fixed missing entry from LD_LIBRARY_PATH for git pull to function

### DIFF
--- a/ci-common/Dockerfile
+++ b/ci-common/Dockerfile
@@ -37,7 +37,7 @@ RUN source /tmp/versions_common.sh && \
 RUN mkdir /opt/aswf
 WORKDIR /opt/aswf
 
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/lib64:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/lib:${LD_LIBRARY_PATH} \
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/opt/rh/httpd24/root/usr/lib64:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/lib64:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/lib:${LD_LIBRARY_PATH} \
     PATH=/opt/rh/rh-git218/root/usr/bin:/usr/local/bin:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin/:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
     CI_COMMON_VERSION=${CI_COMMON_VERSION} \
     DTS_VERSION=${DTS_VERSION} \


### PR DESCRIPTION
This is a very annoying oversight from yesterday's change.
`git --version` would work but `git pull` would fail all the time... luckily I had only pushed this to `ci-usd`!