### PR TITLE
Enforce LF line endings for .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Avoid Windows line breaks in shell scripts (bound to fail)
+*.sh text eol=lf


### PR DESCRIPTION
If you checkout the repo on Windows with Git's autocrlf enabled, then you will end up with CRLF line breaks. Shell scripts don't go well with CR (^M) characters however. They break scripts and give you misleading error messages such as `: command not found` or `: No such file or director`.