### PR TITLE
Cleanup (ShellCheck, whitespace unification)

### DIFF
--- a/.github/workflows/python-sonar.yml
+++ b/.github/workflows/python-sonar.yml
@@ -19,18 +19,18 @@ jobs:
 
     - name: Install pipenv
       run: pip3 install pipenv
-      
+
     - name: Install aswfdocker and dev dependencies with pipenv
       run: pipenv install --dev
-      
+
     # python unittests with junit XML report and coverage XML Cobertura report for publishing task
     - name: Run pytest
       run: pipenv run pytest python/aswfdocker --doctest-modules --junitxml=test-pytest-results.xml --cov=. --cov-report=xml
-      
+
     # mypy static type checks with junit XML report
     - name: Run mypy
       run: pipenv run mypy python/aswfdocker --junit-xml=test-mypy-results.xml
-      
+
     # prospector linter checks with xunit XML report
     - name: Run prospector linter
       run: pipenv run prospector -F python/aswfdocker --output-format xunit > test-prospector-results.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Documentation](https://git-scm.com/doc).
 
 ### Docker Basics
 
-You will also need to understand how Docker images are built and how 
+You will also need to understand how Docker images are built and how
 to test them. The `aswfdocker` Python utility wraps many of the complexities
 of the Docker build process and must be installed locally before starting.
 Please read the Python [README.md](python/README.md) file for further instructions.
@@ -156,7 +156,7 @@ aswf-docker-dev@lists.aswf.io mail list.
 
 Contributions should be submitted as Github pull requests. See
 [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/)
-if you're unfamiliar with this concept. 
+if you're unfamiliar with this concept.
 
 The development cycle for a code change should follow this protocol:
 
@@ -248,7 +248,7 @@ tests can be run manually by running `pre-commit run --all-files`.
 
 #### Formatting
 
-[Black](https://black.readthedocs.io/en/stable/) is the automatic formatter of choice 
+[Black](https://black.readthedocs.io/en/stable/) is the automatic formatter of choice
 for aswf-docker and is required to be run before any commit.
 
 #### Naming Conventions

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ aswfdocker build -n aswftesting/ci-package-usd:2019
 ```
 
 ### Images
-Images can be build with recent Docker versions but do not require [buildx](https://docs.docker.com/buildx/working-with-buildx/) 
+Images can be build with recent Docker versions but do not require [buildx](https://docs.docker.com/buildx/working-with-buildx/)
 but it is recommended to speed up large builds.
 
 To build all images (very unlikely to succeed unless run on a very very powerful machine!):

--- a/ci-common/Dockerfile
+++ b/ci-common/Dockerfile
@@ -15,7 +15,6 @@ ARG ASWF_ORG
 ARG CI_COMMON_VERSION
 ARG DTS_VERSION
 
-
 LABEL maintainer="aloys.baillet@gmail.com"
 
 LABEL org.opencontainers.image.name="$ASWF_ORG/base-ci"

--- a/ci-common/Dockerfile
+++ b/ci-common/Dockerfile
@@ -39,6 +39,7 @@ WORKDIR /opt/aswf
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/opt/rh/httpd24/root/usr/lib64:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/lib64:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/lib:${LD_LIBRARY_PATH} \
     PATH=/opt/rh/rh-git218/root/usr/bin:/usr/local/bin:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin/:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
     CI_COMMON_VERSION=${CI_COMMON_VERSION} \
+    ASWF_ORG=${ASWF_ORG} \
     DTS_VERSION=${DTS_VERSION} \
     PERL5LIB=/opt/rh/rh-git218/root/usr/share/perl5/vendor_perl \
     MANPATH=/opt/rh/rh-git218/root/usr/share/man
@@ -49,9 +50,6 @@ COPY scripts/common/install_sonar.sh \
 
 COPY --from=ci-package-clang /. /usr/local/
 COPY --from=ci-package-ninja /. /usr/local/
-
-ENV CI_COMMON_VERSION=${CI_COMMON_VERSION} \
-    ASWF_ORG=${ASWF_ORG}
 
 RUN export DOWNLOADS_DIR=/tmp/downloads && \
     mkdir /tmp/downloads && \

--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -69,7 +69,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-clang ####################
-# This build target is used to generate a packages of clang that 
+# This build target is used to generate a packages of clang that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-clang
@@ -96,7 +96,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-ninja ####################
-# This build target is used to generate a packages of ninja that 
+# This build target is used to generate a packages of ninja that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-ninja
@@ -140,7 +140,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-boost ####################
-# This build target is used to generate a packages of boost that 
+# This build target is used to generate a packages of boost that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-python
@@ -167,7 +167,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-boost ####################
-# This build target is used to generate a packages of boost that 
+# This build target is used to generate a packages of boost that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-boost
@@ -191,7 +191,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-tbb ####################
-# This build target is used to generate a packages of tbb that 
+# This build target is used to generate a packages of tbb that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-tbb
@@ -215,7 +215,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-cppunit ####################
-# This build target is used to generate a packages of cppunit that 
+# This build target is used to generate a packages of cppunit that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-cppunit
@@ -239,7 +239,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-log4cplus ####################
-# This build target is used to generate a packages of log4cplus that 
+# This build target is used to generate a packages of log4cplus that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-log4cplus
@@ -263,7 +263,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-glew ####################
-# This build target is used to generate a packages of glew that 
+# This build target is used to generate a packages of glew that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-glew
@@ -288,7 +288,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-glfw ####################
-# This build target is used to generate a packages of glfw that 
+# This build target is used to generate a packages of glfw that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-glfw
@@ -312,7 +312,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-qt ####################
-# This build target is used to generate a packages of qt that 
+# This build target is used to generate a packages of qt that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-qt
@@ -341,7 +341,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-pyside ####################
-# This build target is used to generate a packages of pyside that 
+# This build target is used to generate a packages of pyside that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-pyside
@@ -370,7 +370,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-openexr ####################
-# This build target is used to generate a packages of openexr that 
+# This build target is used to generate a packages of openexr that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-openexr
@@ -395,7 +395,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-blosc ####################
-# This build target is used to generate a packages of blosc that 
+# This build target is used to generate a packages of blosc that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-blosc
@@ -420,7 +420,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-partio ####################
-# This build target is used to generate a packages of partio that 
+# This build target is used to generate a packages of partio that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-partio
@@ -444,7 +444,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-oiio ####################
-# This build target is used to generate a packages of oiio that 
+# This build target is used to generate a packages of oiio that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-oiio
@@ -468,7 +468,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-ocio ####################
-# This build target is used to generate a packages of ocio that 
+# This build target is used to generate a packages of ocio that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-ocio
@@ -496,7 +496,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-osl ####################
-# This build target is used to generate a packages of osl that 
+# This build target is used to generate a packages of osl that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-osl
@@ -520,7 +520,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-alembic ####################
-# This build target is used to generate a packages of alembic that 
+# This build target is used to generate a packages of alembic that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-alembic
@@ -545,7 +545,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-ptex ####################
-# This build target is used to generate a packages of ptex that 
+# This build target is used to generate a packages of ptex that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-ptex
@@ -575,7 +575,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-opensubdiv ####################
-# This build target is used to generate a packages of opensubdiv that 
+# This build target is used to generate a packages of opensubdiv that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-opensubdiv
@@ -607,7 +607,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-openvdb ####################
-# This build target is used to generate a packages of openvdb that 
+# This build target is used to generate a packages of openvdb that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-openvdb
@@ -641,7 +641,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-usd ####################
-# This build target is used to generate a packages of usd that 
+# This build target is used to generate a packages of usd that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-usd
@@ -671,7 +671,7 @@ RUN --mount=type=cache,target=/tmp/ccache \
 
 
 #################### ci-package-otio ####################
-# This build target is used to generate a package of otio that 
+# This build target is used to generate a package of otio that
 # can be placed in a downloadable artifact
 
 FROM scratch as ci-package-otio

--- a/scripts/base/build_boost.sh
+++ b/scripts/base/build_boost.sh
@@ -27,13 +27,13 @@ fi
 mkdir boost
 cd boost
 
-if [ ! -f $DOWNLOADS_DIR/boost-${BOOST_VERSION}.tar.gz ]; then
-    curl --location https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION_U}.tar.gz -o $DOWNLOADS_DIR/boost-${BOOST_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/boost-${BOOST_VERSION}.tar.gz" ]; then
+    curl --location "https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION_U}.tar.gz" -o "$DOWNLOADS_DIR/boost-${BOOST_VERSION}.tar.gz"
 fi
 
-tar -xzf $DOWNLOADS_DIR/boost-${BOOST_VERSION}.tar.gz
+tar -xzf "$DOWNLOADS_DIR/boost-${BOOST_VERSION}.tar.gz"
 
-cd boost_${BOOST_VERSION_U}
+cd "boost_${BOOST_VERSION_U}"
 sh bootstrap.sh ${BOOTSTRAP_ARGS}
 ./b2 install -j2 variant=release toolset=gcc link=shared \
     --with-atomic \
@@ -61,7 +61,7 @@ sh bootstrap.sh ${BOOTSTRAP_ARGS}
     --with-timer \
     --with-type_erasure \
     --with-wave \
-    --prefix=${ASWF_INSTALL_PREFIX} \
+    --prefix="${ASWF_INSTALL_PREFIX}" \
     --with-python \
     ${BOOST_EXTRA_ARGS}
 

--- a/scripts/base/build_cppunit.sh
+++ b/scripts/base/build_cppunit.sh
@@ -4,16 +4,16 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/cppunit-${CPPUNIT_VERSION}.tar.gz ]; then
-    curl --location http://dev-www.libreoffice.org/src/cppunit-${CPPUNIT_VERSION}.tar.gz -o $DOWNLOADS_DIR/cppunit-${CPPUNIT_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/cppunit-${CPPUNIT_VERSION}.tar.gz" ]; then
+    curl --location "http://dev-www.libreoffice.org/src/cppunit-${CPPUNIT_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/cppunit-${CPPUNIT_VERSION}.tar.gz"
 fi
 
-tar xf $DOWNLOADS_DIR/cppunit-${CPPUNIT_VERSION}.tar.gz
-cd cppunit-${CPPUNIT_VERSION}
+tar xf "$DOWNLOADS_DIR/cppunit-${CPPUNIT_VERSION}.tar.gz"
+cd "cppunit-${CPPUNIT_VERSION}"
 
-./configure --prefix=${ASWF_INSTALL_PREFIX}
+./configure --prefix="${ASWF_INSTALL_PREFIX}"
 make -j$(nproc)
 make install
 
 cd ..
-rm -rf cppunit-${CPPUNIT_VERSION}
+rm -rf "cppunit-${CPPUNIT_VERSION}"

--- a/scripts/base/build_glew.sh
+++ b/scripts/base/build_glew.sh
@@ -4,16 +4,16 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/glew-${GLEW_VERSION}.tgz ]; then
-    curl --location https://github.com/nigels-com/glew/releases/download/glew-${GLEW_VERSION}/glew-${GLEW_VERSION}.tgz -o $DOWNLOADS_DIR/glew-${GLEW_VERSION}.tgz
+if [ ! -f "$DOWNLOADS_DIR/glew-${GLEW_VERSION}.tgz" ]; then
+    curl --location "https://github.com/nigels-com/glew/releases/download/glew-${GLEW_VERSION}/glew-${GLEW_VERSION}.tgz" -o "$DOWNLOADS_DIR/glew-${GLEW_VERSION}.tgz"
 fi
 
-tar xf $DOWNLOADS_DIR/glew-${GLEW_VERSION}.tgz
+tar xf "$DOWNLOADS_DIR/glew-${GLEW_VERSION}.tgz"
 
-cd glew-${GLEW_VERSION}/build
-cmake ./cmake -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX}
+cd "glew-${GLEW_VERSION}/build"
+cmake ./cmake -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}"
 make -j$(nproc)
 make install
 
 cd ../..
-rm -rf glew-${GLEW_VERSION}
+rm -rf "glew-${GLEW_VERSION}"

--- a/scripts/base/build_glfw.sh
+++ b/scripts/base/build_glfw.sh
@@ -8,13 +8,13 @@ git clone https://github.com/glfw/glfw.git
 cd glfw
 
 if [ "$GLFW_VERSION" != "latest" ]; then
-    git checkout tags/${GLFW_VERSION} -b ${GLFW_VERSION}
+    git checkout "tags/${GLFW_VERSION}" -b "${GLFW_VERSION}"
 fi
 
 mkdir build
 cd build
 
-cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} ..
+cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" ..
 make -j$(nproc)
 make install
 

--- a/scripts/base/build_log4cplus.sh
+++ b/scripts/base/build_log4cplus.sh
@@ -13,12 +13,12 @@ git clone https://github.com/log4cplus/log4cplus.git
 cd log4cplus
 
 if [ "$LOG4CPLUS_VERSION" != "latest" ]; then
-    git checkout tags/REL_${LOG4CPLUS_MAJOR}_${LOG4CPLUS_MINOR}_${LOG4CPLUS_PATCH} -b ${LOG4CPLUS_VERSION}
+    git checkout "tags/REL_${LOG4CPLUS_MAJOR}_${LOG4CPLUS_MINOR}_${LOG4CPLUS_PATCH}" -b "${LOG4CPLUS_VERSION}"
 fi
 
 mkdir build
 cd build
-cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} ..
+cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" ..
 make -j$(nproc)
 make install
 

--- a/scripts/base/build_pyside.sh
+++ b/scripts/base/build_pyside.sh
@@ -18,22 +18,22 @@ Prefix = /tmp/qt5temp
 EOF
 
 if [[ $PYSIDE_VERSION == 2.0.0 ]]; then
-    curl --location https://www.autodesk.com/content/dam/autodesk/www/Company/files/pyside2-maya2018.4.zip -o $DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.zip
-    unzip $DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.zip
+    curl --location "https://www.autodesk.com/content/dam/autodesk/www/Company/files/pyside2-maya2018.4.zip" -o "$DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.zip"
+    unzip "$DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.zip"
     mv pyside-setup pyside
     cd pyside
-    ${ASWF_INSTALL_PREFIX}/bin/python setup.py build install --prefix ${ASWF_INSTALL_PREFIX}
+    "${ASWF_INSTALL_PREFIX}/bin/python" setup.py build install --prefix "${ASWF_INSTALL_PREFIX}"
 else
     if [[ $PYSIDE_VERSION == 5.12.6 ]]; then
         PYSIDE_URL_NAME=pyside-setup-everywhere-src-${PYSIDE_VERSION}
     else
         PYSIDE_URL_NAME=pyside-setup-opensource-src-${PYSIDE_VERSION}
     fi
-    if [ ! -f $DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.tar.xz ]; then
-        curl --location https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${PYSIDE_VERSION}-src/${PYSIDE_URL_NAME}.tar.xz -o $DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.tar.xz
+    if [ ! -f "$DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.tar.xz" ]; then
+        curl --location "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-${PYSIDE_VERSION}-src/${PYSIDE_URL_NAME}.tar.xz" -o "$DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.tar.xz"
     fi
-    tar xf $DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.tar.xz
-    mv ${PYSIDE_URL_NAME} pyside
+    tar xf "$DOWNLOADS_DIR/pyside-${PYSIDE_VERSION}.tar.xz"
+    mv "${PYSIDE_URL_NAME}" pyside
 
     export LLVM_INSTALL_DIR=${ASWF_INSTALL_PREFIX}
     export CLANG_INSTALL_DIR=${ASWF_INSTALL_PREFIX}
@@ -42,19 +42,19 @@ else
 
     if [[ $PYSIDE_VERSION == 5.12.6 ]]; then
         # Apply typing patch
-        curl --location https://codereview.qt-project.org/changes/pyside%2Fpyside-setup~271412/revisions/4/patch?zip -o typing-patch.zip
+        curl --location "https://codereview.qt-project.org/changes/pyside%2Fpyside-setup~271412/revisions/4/patch?zip" -o "typing-patch.zip"
         unzip typing-patch.zip
         patch -p1 < 28958df.diff
     fi
     if [[ $PYSIDE_VERSION == 5.12.6 ]]; then
         # Apply clang10 patch
-        curl --location https://codereview.qt-project.org/changes/pyside%2Fpyside-setup~296271/revisions/2/patch?zip -o clang10-patch.zip
+        curl --location "https://codereview.qt-project.org/changes/pyside%2Fpyside-setup~296271/revisions/2/patch?zip" -o "clang10-patch.zip"
         unzip clang10-patch.zip
         patch -p1 < 9ae6382.diff
     fi
 
-    ${ASWF_INSTALL_PREFIX}/bin/python setup.py build --parallel=$(nproc)
-    ${ASWF_INSTALL_PREFIX}/bin/python setup.py install --prefix ${ASWF_INSTALL_PREFIX}
+    "${ASWF_INSTALL_PREFIX}/bin/python" setup.py build --parallel=$(nproc)
+    "${ASWF_INSTALL_PREFIX}/bin/python" setup.py install --prefix "${ASWF_INSTALL_PREFIX}"
 
 fi
 

--- a/scripts/base/build_pyside.sh
+++ b/scripts/base/build_pyside.sh
@@ -37,7 +37,7 @@ else
 
     export LLVM_INSTALL_DIR=${ASWF_INSTALL_PREFIX}
     export CLANG_INSTALL_DIR=${ASWF_INSTALL_PREFIX}
-    
+
     cd pyside
 
     if [[ $PYSIDE_VERSION == 5.12.6 ]]; then

--- a/scripts/base/build_python.sh
+++ b/scripts/base/build_python.sh
@@ -7,14 +7,14 @@ set -ex
 mkdir python
 cd python
 
-curl -C - --location https://www.python.org/ftp/python/${PYTHON_VERSION_FULL}/Python-${PYTHON_VERSION_FULL}.tgz -o $DOWNLOADS_DIR/Python-${PYTHON_VERSION_FULL}.tgz
+curl -C - --location "https://www.python.org/ftp/python/${PYTHON_VERSION_FULL}/Python-${PYTHON_VERSION_FULL}.tgz" -o "$DOWNLOADS_DIR/Python-${PYTHON_VERSION_FULL}.tgz"
 
 
-mkdir -p ${ASWF_INSTALL_PREFIX}/bin
+mkdir -p "${ASWF_INSTALL_PREFIX}/bin"
 echo "PATH=$PATH"
 
 # Create script to allow use of system python
-cat <<EOF > ${ASWF_INSTALL_PREFIX}/bin/run-with-system-python
+cat <<EOF > "${ASWF_INSTALL_PREFIX}/bin/run-with-system-python"
 #!/bin/sh
 # Unsets all environment variables so that the system python can function normally
 # To use, just prefix any command with run-with-system-python
@@ -25,22 +25,22 @@ export LD_LIBRARY_PATH=/opt/rh/devtoolset-${DTS_VERSION}/root/usr/lib64:/opt/rh/
 export PATH=/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin:/opt/app-root/src/bin:/opt/rh/devtoolset-${DTS_VERSION}/root/usr/bin/:/usr/sbin:/usr/bin:/sbin:/bin
 exec "\$@"
 EOF
-chmod a+x ${ASWF_INSTALL_PREFIX}/bin/run-with-system-python
+chmod a+x "${ASWF_INSTALL_PREFIX}/bin/run-with-system-python"
 
 # Create a yum wrapper that uses the system python
-cat <<EOF > ${ASWF_INSTALL_PREFIX}/bin/yum
+cat <<EOF > "${ASWF_INSTALL_PREFIX}/bin/yum"
 #!/bin/sh
 # This runs yum with system python
-exec ${ASWF_INSTALL_PREFIX}/bin/run-with-system-python /usr/bin/yum "\$@"
+exec "${ASWF_INSTALL_PREFIX}/bin/run-with-system-python" /usr/bin/yum "\$@"
 EOF
-chmod a+x ${ASWF_INSTALL_PREFIX}/bin/yum
+chmod a+x "${ASWF_INSTALL_PREFIX}/bin/yum"
 
-tar xf $DOWNLOADS_DIR/Python-${PYTHON_VERSION_FULL}.tgz
-cd Python-${PYTHON_VERSION_FULL}
+tar xf "$DOWNLOADS_DIR/Python-${PYTHON_VERSION_FULL}.tgz"
+cd "Python-${PYTHON_VERSION_FULL}"
 
 # Ensure configure, build and install is done with no reference to ${ASWF_INSTALL_PREFIX} as this somehow messes up the system install
 run-with-system-python ./configure \
-    --prefix=${ASWF_INSTALL_PREFIX} \
+    --prefix="${ASWF_INSTALL_PREFIX}" \
     --enable-unicode=ucs4 \
     --enable-shared
 run-with-system-python make -j$(nproc)
@@ -49,7 +49,7 @@ run-with-system-python make install
 
 if [[ $PYTHON_VERSION == 3* ]]; then
     # Create symlink from python3 to python
-    ln -s python3 ${ASWF_INSTALL_PREFIX}/bin/python
+    ln -s python3 "${ASWF_INSTALL_PREFIX}/bin/python"
     export PIP=pip3
 else
     export PIP=pip

--- a/scripts/base/build_qt.sh
+++ b/scripts/base/build_qt.sh
@@ -11,25 +11,25 @@ ccache --max-size=10G
 #ccache --clear
 
 if [[ $QT_VERSION == 5.6.1 ]]; then
-    if [ ! -f $DOWNLOADS_DIR/qt-${QT_VERSION}.zip ]; then
-        curl --location https://www.autodesk.com/content/dam/autodesk/www/Company/files/2019/qt561formaya2019.zip -o $DOWNLOADS_DIR/qt-${QT_VERSION}.zip
+    if [ ! -f "$DOWNLOADS_DIR/qt-${QT_VERSION}.zip" ]; then
+        curl --location "https://www.autodesk.com/content/dam/autodesk/www/Company/files/2019/qt561formaya2019.zip" -o "$DOWNLOADS_DIR/qt-${QT_VERSION}.zip"
     fi
-    unzip $DOWNLOADS_DIR/qt-${QT_VERSION}.zip
+    unzip "$DOWNLOADS_DIR/qt-${QT_VERSION}.zip"
     mv qt-adsk-5.6.1-vfx qt-src
     cd qt-src
     tar xf ../qt561-webkit.tgz
 else
     QT_MAJOR_MINOR=$(echo "${QT_VERSION}" | cut -d. -f-2)
-    if [ ! -f $DOWNLOADS_DIR/qt-${QT_VERSION}.tar.xz ]; then
-        curl --location http://download.qt.io/official_releases/qt/${QT_MAJOR_MINOR}/${QT_VERSION}/single/qt-everywhere-src-${QT_VERSION}.tar.xz -o $DOWNLOADS_DIR/qt-${QT_VERSION}.tar.xz
+    if [ ! -f "$DOWNLOADS_DIR/qt-${QT_VERSION}.tar.xz" ]; then
+        curl --location "http://download.qt.io/official_releases/qt/${QT_MAJOR_MINOR}/${QT_VERSION}/single/qt-everywhere-src-${QT_VERSION}.tar.xz" -o "$DOWNLOADS_DIR/qt-${QT_VERSION}.tar.xz"
     fi
-    tar xf $DOWNLOADS_DIR/qt-${QT_VERSION}.tar.xz
-    mv qt-everywhere-src-${QT_VERSION} qt-src
+    tar xf "$DOWNLOADS_DIR/qt-${QT_VERSION}.tar.xz"
+    mv "qt-everywhere-src-${QT_VERSION}" qt-src
     cd qt-src
 fi
 
 ./configure \
-    --prefix=${ASWF_INSTALL_PREFIX} \
+    --prefix="${ASWF_INSTALL_PREFIX}" \
         -no-strip \
         -no-rpath \
         -opensource \

--- a/scripts/base/build_tbb.sh
+++ b/scripts/base/build_tbb.sh
@@ -8,17 +8,17 @@ git clone https://github.com/01org/tbb.git
 cd tbb
 
 if [ "$TBB_VERSION" != "latest" ]; then
-    git checkout tags/${TBB_VERSION} -b ${TBB_VERSION}
+    git checkout "tags/${TBB_VERSION}" -b "${TBB_VERSION}"
 fi
 
 make -j$(nproc)
 
-mkdir -p ${ASWF_INSTALL_PREFIX}/include
-mkdir -p ${ASWF_INSTALL_PREFIX}/lib
+mkdir -p "${ASWF_INSTALL_PREFIX}/include"
+mkdir -p "${ASWF_INSTALL_PREFIX}/lib"
 
-cp -r include/serial ${ASWF_INSTALL_PREFIX}/include/.
-cp -r include/tbb ${ASWF_INSTALL_PREFIX}/include/.
-cp -r build/*/*.so* ${ASWF_INSTALL_PREFIX}/lib/.
+cp -r include/serial "${ASWF_INSTALL_PREFIX}/include/."
+cp -r include/tbb "${ASWF_INSTALL_PREFIX}/include/."
+cp -r build/*/*.so* "${ASWF_INSTALL_PREFIX}/lib/."
 
 cd ..
 rm -rf tbb

--- a/scripts/base/install_cmake.sh
+++ b/scripts/base/install_cmake.sh
@@ -4,8 +4,8 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/cmake-${CMAKE_VERSION}-Linux-x86_64.sh ]; then
-    curl --location "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh" -o $DOWNLOADS_DIR/cmake-${CMAKE_VERSION}-Linux-x86_64.sh
+if [ ! -f "$DOWNLOADS_DIR/cmake-${CMAKE_VERSION}-Linux-x86_64.sh" ]; then
+    curl --location "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh" -o "$DOWNLOADS_DIR/cmake-${CMAKE_VERSION}-Linux-x86_64.sh"
 fi
 
-sh $DOWNLOADS_DIR/cmake-${CMAKE_VERSION}-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir
+sh "$DOWNLOADS_DIR/cmake-${CMAKE_VERSION}-Linux-x86_64.sh" --skip-license --prefix=/usr/local --exclude-subdir

--- a/scripts/common/before_build.sh
+++ b/scripts/common/before_build.sh
@@ -6,5 +6,5 @@ set -ex
 
 rm -rf /package
 
-cd ${ASWF_INSTALL_PREFIX}
+cd "${ASWF_INSTALL_PREFIX}"
 find . -type f -o -type l | cut -c3- > /tmp/previous-prefix-files.txt

--- a/scripts/common/build_clang.sh
+++ b/scripts/common/build_clang.sh
@@ -4,21 +4,21 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/llvmorg-${CLANG_VERSION}.tar.gz ]; then
-    curl --location https://github.com/llvm/llvm-project/archive/llvmorg-${CLANG_VERSION}.tar.gz -o $DOWNLOADS_DIR/llvmorg-${CLANG_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/llvmorg-${CLANG_VERSION}.tar.gz" ]; then
+    curl --location "https://github.com/llvm/llvm-project/archive/llvmorg-${CLANG_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/llvmorg-${CLANG_VERSION}.tar.gz"
 fi
 
-tar xf $DOWNLOADS_DIR/llvmorg-${CLANG_VERSION}.tar.gz
-cd llvm-project-llvmorg-${CLANG_VERSION}/llvm
+tar xf "$DOWNLOADS_DIR/llvmorg-${CLANG_VERSION}.tar.gz"
+cd "llvm-project-llvmorg-${CLANG_VERSION}/llvm"
 
 mkdir build
 cd build
 cmake -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;libcxx;libcxxabi;compiler-rt;lld" \
       -DCMAKE_BUILD_TYPE=Release \
       -G "Unix Makefiles" \
-      -DGCC_INSTALL_PREFIX=/opt/rh/devtoolset-${DTS_VERSION}/root/usr \
+      -DGCC_INSTALL_PREFIX="/opt/rh/devtoolset-${DTS_VERSION}/root/usr" \
       -DLLVM_TARGETS_TO_BUILD="host;NVPTX" \
-      -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
+      -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" \
       -DCLANG_INCLUDE_DOCS=OFF \
       -DLIBCXX_INCLUDE_DOCS=OFF \
       -DLLVM_BUILD_TESTS=OFF \
@@ -56,4 +56,4 @@ make -j$(nproc)
 make install
 
 cd ../../..
-rm -rf llvm-project-llvmorg-${CLANG_VERSION}
+rm -rf "llvm-project-llvmorg-${CLANG_VERSION}"

--- a/scripts/common/build_ninja.sh
+++ b/scripts/common/build_ninja.sh
@@ -4,12 +4,12 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/ninja-${NINJA_VERSION}.tar.gz ]; then
-    curl --location https://github.com/ninja-build/ninja/archive/v${NINJA_VERSION}.tar.gz -o $DOWNLOADS_DIR/ninja-${NINJA_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/ninja-${NINJA_VERSION}.tar.gz" ]; then
+    curl --location "https://github.com/ninja-build/ninja/archive/v${NINJA_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/ninja-${NINJA_VERSION}.tar.gz"
 fi
 
-tar xf $DOWNLOADS_DIR/ninja-${NINJA_VERSION}.tar.gz
-cd ninja-${NINJA_VERSION}
+tar xf "$DOWNLOADS_DIR/ninja-${NINJA_VERSION}.tar.gz"
+cd "ninja-${NINJA_VERSION}"
 
 ./configure.py --bootstrap
 

--- a/scripts/common/copy_new_files.sh
+++ b/scripts/common/copy_new_files.sh
@@ -6,6 +6,6 @@ set -ex
 
 mkdir -p /package
 
-cd ${ASWF_INSTALL_PREFIX}
+cd "${ASWF_INSTALL_PREFIX}"
 find . -type l -o -type f | cut -c3- > /tmp/new-prefix-files.txt
 rsync -av --files-from=/tmp/new-prefix-files.txt --exclude-from=/tmp/previous-prefix-files.txt . /package/

--- a/scripts/common/install_ccache.sh
+++ b/scripts/common/install_ccache.sh
@@ -7,13 +7,13 @@ set -ex
 mkdir ccache
 cd ccache
 
-if [ ! -f $DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz ]; then
-    curl --location https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o $DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz" ]; then
+    curl --location "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz"
 fi
 
-tar xf $DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz
+tar xf "$DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz"
 
-cd ccache-${CCACHE_VERSION}
+cd "ccache-${CCACHE_VERSION}"
 ./configure --prefix=/usr/local
 make -j$(nproc)
 make install
@@ -29,7 +29,7 @@ ln -s /usr/local/bin/ccache /usr/local/bin/_ccache/clang
 # Create activate_ccache.sh script
 cat <<EOF > /usr/local/bin/activate_ccache.sh
 #!/usr/bin/env bash
-export PATH=/usr/local/bin/_ccache:$PATH
+PATH=/usr/local/bin/_ccache:$PATH
 if [ -z "$CCACHE_DIR"]
 then
     export CCACHE_DIR=/tmp/ccache

--- a/scripts/common/install_ccache.sh
+++ b/scripts/common/install_ccache.sh
@@ -29,7 +29,7 @@ ln -s /usr/local/bin/ccache /usr/local/bin/_ccache/clang
 # Create activate_ccache.sh script
 cat <<EOF > /usr/local/bin/activate_ccache.sh
 #!/usr/bin/env bash
-PATH=/usr/local/bin/_ccache:$PATH
+export PATH=/usr/local/bin/_ccache:$PATH
 if [ -z "$CCACHE_DIR"]
 then
     export CCACHE_DIR=/tmp/ccache

--- a/scripts/common/install_dev_ccache.sh
+++ b/scripts/common/install_dev_ccache.sh
@@ -8,13 +8,13 @@ mkdir ccache
 cd ccache
 
 CCACHE_VERSION=3.7.9
-if [ ! -f $DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz ]; then
-    curl --location https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz -o $DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz" ]; then
+    curl --location "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz"
 fi
 
-tar xf $DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz
+tar xf "$DOWNLOADS_DIR/ccache-${CCACHE_VERSION}.tar.gz"
 
-cd ccache-${CCACHE_VERSION}
+cd "ccache-${CCACHE_VERSION}"
 ./configure --prefix=/opt/aswfbuilder
 make -j$(nproc)
 make install

--- a/scripts/common/install_dev_cmake.sh
+++ b/scripts/common/install_dev_cmake.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/cmake-${PKGS_COMMON_CMAKE_VERSION}-Linux-x86_64.sh ]; then
-    curl --location "https://github.com/Kitware/CMake/releases/download/v${PKGS_COMMON_CMAKE_VERSION}/cmake-${PKGS_COMMON_CMAKE_VERSION}-Linux-x86_64.sh" -o $DOWNLOADS_DIR/cmake-${PKGS_COMMON_CMAKE_VERSION}-Linux-x86_64.sh
+if [ ! -f "$DOWNLOADS_DIR/cmake-${PKGS_COMMON_CMAKE_VERSION}-Linux-x86_64.sh" ]; then
+    curl --location "https://github.com/Kitware/CMake/releases/download/v${PKGS_COMMON_CMAKE_VERSION}/cmake-${PKGS_COMMON_CMAKE_VERSION}-Linux-x86_64.sh" -o "$DOWNLOADS_DIR/cmake-${PKGS_COMMON_CMAKE_VERSION}-Linux-x86_64.sh"
 fi
-sh $DOWNLOADS_DIR/cmake-${PKGS_COMMON_CMAKE_VERSION}-Linux-x86_64.sh --skip-license --prefix=/opt/aswfbuilder --exclude-subdir
+sh "$DOWNLOADS_DIR/cmake-${PKGS_COMMON_CMAKE_VERSION}-Linux-x86_64.sh" --skip-license --prefix=/opt/aswfbuilder --exclude-subdir

--- a/scripts/common/install_sonar.sh
+++ b/scripts/common/install_sonar.sh
@@ -13,7 +13,7 @@ fi
 unzip "$DOWNLOADS_DIR/sonar-bw.zip"
 mv build-wrapper-linux-x86 /var/opt/.
 ln -s /var/opt/build-wrapper-linux-x86/build-wrapper-linux-x86-64 /usr/bin/build-wrapper-linux-x86-64
-echo $(build-wrapper-linux-x86-64 --help)
+build-wrapper-linux-x86-64 --help
 
 if [ ! -f "$DOWNLOADS_DIR/sonar-scanner.zip" ]; then
     curl --location "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip" -o "$DOWNLOADS_DIR/sonar-scanner.zip"
@@ -21,7 +21,7 @@ fi
 unzip "$DOWNLOADS_DIR/sonar-scanner.zip"
 mv "sonar-scanner-${SONAR_VERSION}-linux" /var/opt/.
 ln -s "/var/opt/sonar-scanner-${SONAR_VERSION}-linux/bin/sonar-scanner" /usr/bin/sonar-scanner
-echo $(sonar-scanner --help)
+sonar-scanner --help
 
 cd ..
 rm -rf sonar

--- a/scripts/common/install_sonar.sh
+++ b/scripts/common/install_sonar.sh
@@ -13,7 +13,8 @@ fi
 unzip "$DOWNLOADS_DIR/sonar-bw.zip"
 mv build-wrapper-linux-x86 /var/opt/.
 ln -s /var/opt/build-wrapper-linux-x86/build-wrapper-linux-x86-64 /usr/bin/build-wrapper-linux-x86-64
-build-wrapper-linux-x86-64 --help
+# Returns with non-zero exit code, catch error with $()
+echo $(build-wrapper-linux-x86-64 --help)
 
 if [ ! -f "$DOWNLOADS_DIR/sonar-scanner.zip" ]; then
     curl --location "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip" -o "$DOWNLOADS_DIR/sonar-scanner.zip"

--- a/scripts/common/install_sonar.sh
+++ b/scripts/common/install_sonar.sh
@@ -14,7 +14,7 @@ unzip "$DOWNLOADS_DIR/sonar-bw.zip"
 mv build-wrapper-linux-x86 /var/opt/.
 ln -s /var/opt/build-wrapper-linux-x86/build-wrapper-linux-x86-64 /usr/bin/build-wrapper-linux-x86-64
 # Returns with non-zero exit code, catch error with $()
-echo $(build-wrapper-linux-x86-64 --help)
+echo $(build-wrapper-linux-x86-64)
 
 if [ ! -f "$DOWNLOADS_DIR/sonar-scanner.zip" ]; then
     curl --location "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip" -o "$DOWNLOADS_DIR/sonar-scanner.zip"

--- a/scripts/common/install_sonar.sh
+++ b/scripts/common/install_sonar.sh
@@ -7,20 +7,20 @@ set -ex
 mkdir sonar
 cd sonar
 
-if [ ! -f $DOWNLOADS_DIR/sonar-bw.zip ]; then
-    curl --location https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip -o $DOWNLOADS_DIR/sonar-bw.zip
+if [ ! -f "$DOWNLOADS_DIR/sonar-bw.zip" ]; then
+    curl --location "https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip" -o "$DOWNLOADS_DIR/sonar-bw.zip"
 fi
-unzip $DOWNLOADS_DIR/sonar-bw.zip
+unzip "$DOWNLOADS_DIR/sonar-bw.zip"
 mv build-wrapper-linux-x86 /var/opt/.
 ln -s /var/opt/build-wrapper-linux-x86/build-wrapper-linux-x86-64 /usr/bin/build-wrapper-linux-x86-64
 echo $(build-wrapper-linux-x86-64 --help)
 
-if [ ! -f $DOWNLOADS_DIR/sonar-scanner.zip ]; then
-    curl --location https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip -o $DOWNLOADS_DIR/sonar-scanner.zip
+if [ ! -f "$DOWNLOADS_DIR/sonar-scanner.zip" ]; then
+    curl --location "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip" -o "$DOWNLOADS_DIR/sonar-scanner.zip"
 fi
-unzip $DOWNLOADS_DIR/sonar-scanner.zip
-mv sonar-scanner-${SONAR_VERSION}-linux /var/opt/.
-ln -s /var/opt/sonar-scanner-${SONAR_VERSION}-linux/bin/sonar-scanner /usr/bin/sonar-scanner
+unzip "$DOWNLOADS_DIR/sonar-scanner.zip"
+mv "sonar-scanner-${SONAR_VERSION}-linux" /var/opt/.
+ln -s "/var/opt/sonar-scanner-${SONAR_VERSION}-linux/bin/sonar-scanner" /usr/bin/sonar-scanner
 echo $(sonar-scanner --help)
 
 cd ..

--- a/scripts/common/install_yumpackages.sh
+++ b/scripts/common/install_yumpackages.sh
@@ -106,7 +106,7 @@ yum install --setopt=tsflags=nodocs -y \
     xorg-x11-xkb-utils xorg-x11-xkb-utils-devel \
     xorg-x11-server-Xvfb \
     xz-devel \
-    zlib-devel                                                                                        
+    zlib-devel
 
 # This is needed for Xvfb to function properly.
 dbus-uuidgen > /etc/machine-id

--- a/scripts/common/install_yumpackages.sh
+++ b/scripts/common/install_yumpackages.sh
@@ -121,7 +121,7 @@ if [[ $DTS_VERSION == 6 ]]; then
 fi
 
 yum install -y --setopt=tsflags=nodocs \
-    devtoolset-$DTS_VERSION-toolchain
+    "devtoolset-$DTS_VERSION-toolchain"
 
 yum install -y epel-release
 

--- a/scripts/tests/1/test_common.sh
+++ b/scripts/tests/1/test_common.sh
@@ -4,33 +4,32 @@
 
 set -ex
 
-clang_v=`clang --version`
+clang_v=$(clang --version)
 if [[ $clang_v != clang\ version\ 7.0* ]]
 then
     exit 1
 fi
 
-clang_tidy_v=`clang-tidy --version`
+clang_tidy_v=$(clang-tidy --version)
 if [[ $clang_tidy_v != *LLVM\ version\ 7.0* ]]
 then
     exit 1
 fi
 
-gcc_v=`gcc --version`
+gcc_v=$(gcc --version)
 if [[ $gcc_v != gcc\ \(GCC\)\ 6.3* ]]
 then
     exit 1
 fi
 
-ninja_v=`ninja --version`
+ninja_v=$(ninja --version)
 if [[ $ninja_v != 1.* ]]
 then
     exit 1
 fi
 
-git_v=`git --version`
+git_v=$(git --version)
 if [[ $git_v != 2.* ]]
 then
     exit 1
 fi
-

--- a/scripts/tests/2/test_common.sh
+++ b/scripts/tests/2/test_common.sh
@@ -4,33 +4,32 @@
 
 set -ex
 
-clang_v=`clang --version`
+clang_v=$(clang --version)
 if [[ $clang_v != clang\ version\ 10.0* ]]
 then
     exit 1
 fi
 
-clang_tidy_v=`clang-tidy --version`
+clang_tidy_v=$(clang-tidy --version)
 if [[ $clang_tidy_v != *LLVM\ version\ 10.0* ]]
 then
     exit 1
 fi
 
-gcc_v=`gcc --version`
+gcc_v=$(gcc --version)
 if [[ $gcc_v != gcc\ \(GCC\)\ 9.3* ]]
 then
     exit 1
 fi
 
-ninja_v=`ninja --version`
+ninja_v=$(ninja --version)
 if [[ $ninja_v != 1.* ]]
 then
     exit 1
 fi
 
-git_v=`git --version`
+git_v=$(git --version)
 if [[ $git_v != 2.* ]]
 then
     exit 1
 fi
-

--- a/scripts/tests/2018/test_base.sh
+++ b/scripts/tests/2018/test_base.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-pypath=`which python`
+pypath=$(which python)
 if [[ $pypath != /usr/local/bin/python ]]
 then
     echo "Wrong python location: $pypath"

--- a/scripts/tests/2018/test_openvdb.sh
+++ b/scripts/tests/2018/test_openvdb.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-git clone https://github.com/AcademySoftwareFoundation/openvdb 
+git clone https://github.com/AcademySoftwareFoundation/openvdb
 cd openvdb
 
 git checkout b5af82007f869a29f6fa1af729f14763e99f85be # Known working at that commit...

--- a/scripts/tests/2019/test_base.sh
+++ b/scripts/tests/2019/test_base.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-pypath=`which python`
+pypath=$(which python)
 if [[ $pypath != /usr/local/bin/python ]]
 then
     echo "Wrong python location: $pypath"

--- a/scripts/tests/2019/test_openvdb.sh
+++ b/scripts/tests/2019/test_openvdb.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-git clone https://github.com/AcademySoftwareFoundation/openvdb 
+git clone https://github.com/AcademySoftwareFoundation/openvdb
 cd openvdb
 
 git checkout b5af82007f869a29f6fa1af729f14763e99f85be # Known working at that commit...

--- a/scripts/tests/2020/test_base.sh
+++ b/scripts/tests/2020/test_base.sh
@@ -4,14 +4,14 @@
 
 set -ex
 
-pypath=`which python`
+pypath=$(which python)
 if [[ $pypath != /usr/local/bin/python ]]
 then
     echo "Wrong python location: $pypath"
     exit 1
 fi
 
-pyversion=`python --version`
+pyversion=$(python --version)
 if [[ $pyversion != Python\ 3.7* ]]
 then
     echo "Wrong python version: $pyversion"

--- a/scripts/vfx/build_alembic.sh
+++ b/scripts/vfx/build_alembic.sh
@@ -7,14 +7,14 @@ set -ex
 mkdir alembic
 cd alembic
 
-if [ ! -f $DOWNLOADS_DIR/hdf5-${HDF5_VERSION}.tar.gz ]; then
-    curl --location https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz -o $DOWNLOADS_DIR/hdf5-${HDF5_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/hdf5-${HDF5_VERSION}.tar.gz" ]; then
+    curl --location "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/hdf5-${HDF5_VERSION}.tar.gz"
 fi
 
-tar -zxf $DOWNLOADS_DIR/hdf5-${HDF5_VERSION}.tar.gz
-cd hdf5-${HDF5_VERSION}
+tar -zxf "$DOWNLOADS_DIR/hdf5-${HDF5_VERSION}.tar.gz"
+cd "hdf5-${HDF5_VERSION}"
 ./configure \
-    --prefix=${ASWF_INSTALL_PREFIX} \
+    --prefix="${ASWF_INSTALL_PREFIX}" \
     --enable-threadsafe \
     --disable-hl \
     --with-pthread=/usr/include
@@ -23,11 +23,11 @@ make install
 
 cd ..
 
-if [ ! -f $DOWNLOADS_DIR/alembic-${ALEMBIC_VERSION}.tar.gz ]; then
-    curl --location https://github.com/alembic/alembic/archive/${ALEMBIC_VERSION}.tar.gz -o $DOWNLOADS_DIR/alembic-${ALEMBIC_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/alembic-${ALEMBIC_VERSION}.tar.gz" ]; then
+    curl --location "https://github.com/alembic/alembic/archive/${ALEMBIC_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/alembic-${ALEMBIC_VERSION}.tar.gz"
 fi
-tar -zxf $DOWNLOADS_DIR/alembic-${ALEMBIC_VERSION}.tar.gz
-cd alembic-${ALEMBIC_VERSION}
+tar -zxf "$DOWNLOADS_DIR/alembic-${ALEMBIC_VERSION}.tar.gz"
+cd "alembic-${ALEMBIC_VERSION}"
 
 # Boost Python3 not found by cmake for PyAlembic as of Alembic 1.7.12
 if [[ $PYTHON_VERSION == 2.7* ]]; then
@@ -37,13 +37,13 @@ else
 fi
 
 cmake \
-    -D CMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
-    -D CMAKE_PREFIX_PATH=${ASWF_INSTALL_PREFIX} \
-    -D BOOST_ROOT=${ASWF_INSTALL_PREFIX} \
-    -D ILMBASE_ROOT=${ASWF_INSTALL_PREFIX} \
+    -D CMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" \
+    -D CMAKE_PREFIX_PATH="${ASWF_INSTALL_PREFIX}" \
+    -D BOOST_ROOT="${ASWF_INSTALL_PREFIX}" \
+    -D ILMBASE_ROOT="${ASWF_INSTALL_PREFIX}" \
     -D Python_ADDITIONAL_VERSIONS=3 \
     -D USE_PYILMBASE=TRUE \
-    -D USE_PYALEMBIC=${USE_PYALEMBIC} \
+    -D USE_PYALEMBIC="${USE_PYALEMBIC}" \
     -D USE_ARNOLD=FALSE \
     -D USE_PRMAN=FALSE \
     -D USE_MAYA=FALSE \

--- a/scripts/vfx/build_blosc.sh
+++ b/scripts/vfx/build_blosc.sh
@@ -8,12 +8,12 @@ git clone https://github.com/Blosc/c-blosc.git
 cd c-blosc
 
 if [ "$BLOSC_VERSION" != "latest" ]; then
-    git checkout tags/v${BLOSC_VERSION} -b v${BLOSC_VERSION}
+    git checkout "tags/v${BLOSC_VERSION}" -b "v${BLOSC_VERSION}"
 fi
 
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX}
+cmake .. -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}"
 make -j$(nproc)
 make install
 

--- a/scripts/vfx/build_ocio.sh
+++ b/scripts/vfx/build_ocio.sh
@@ -8,11 +8,11 @@ mkdir ocio
 cd ocio
 
 
-if [ ! -f $DOWNLOADS_DIR/ocio-${OCIO_VERSION}.tar.gz ]; then
-    curl --location https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v${OCIO_VERSION}.tar.gz -o $DOWNLOADS_DIR/ocio-${OCIO_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/ocio-${OCIO_VERSION}.tar.gz" ]; then
+    curl --location "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v${OCIO_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/ocio-${OCIO_VERSION}.tar.gz"
 fi
-tar -zxf $DOWNLOADS_DIR/ocio-${OCIO_VERSION}.tar.gz
-cd OpenColorIO-${OCIO_VERSION}
+tar -zxf "$DOWNLOADS_DIR/ocio-${OCIO_VERSION}.tar.gz"
+cd "OpenColorIO-${OCIO_VERSION}"
 
 if [[ $DTS_VERSION == 9 && $OCIO_VERSION == 1.* ]]; then
     # Disable warning treated as errors
@@ -23,7 +23,7 @@ fi
 mkdir build
 cd build
 cmake \
-    -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
+    -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" \
     -DOCIO_BUILD_STATIC=OFF \
     -DOCIO_BUILD_TRUELIGHT=OFF \
     -DOCIO_BUILD_APPS=OFF \
@@ -35,13 +35,13 @@ make install
 
 cd ../..
 
-curl --location https://github.com/imageworks/OpenColorIO-Configs/archive/v${OCIO_CONFIGS_VERSION}.tar.gz -o ocio-configs.tar.gz
+curl --location "https://github.com/imageworks/OpenColorIO-Configs/archive/v${OCIO_CONFIGS_VERSION}.tar.gz" -o "ocio-configs.tar.gz"
 tar -zxf ocio-configs.tar.gz
-cd OpenColorIO-Configs-${OCIO_CONFIGS_VERSION}
+cd "OpenColorIO-Configs-${OCIO_CONFIGS_VERSION}"
 
-mkdir ${ASWF_INSTALL_PREFIX}/openColorIO
-cp nuke-default/config.ocio ${ASWF_INSTALL_PREFIX}/openColorIO/
-cp -r nuke-default/luts ${ASWF_INSTALL_PREFIX}/openColorIO/
+mkdir "${ASWF_INSTALL_PREFIX}/openColorIO"
+cp nuke-default/config.ocio "${ASWF_INSTALL_PREFIX}/openColorIO/"
+cp -r nuke-default/luts "${ASWF_INSTALL_PREFIX}/openColorIO/"
 
 cd ../..
 rm -rf ocio

--- a/scripts/vfx/build_oiio.sh
+++ b/scripts/vfx/build_oiio.sh
@@ -8,16 +8,16 @@ git clone https://github.com/OpenImageIO/oiio.git
 cd oiio
 
 if [ "$OIIO_VERSION" != "latest" ]; then
-    git checkout tags/Release-${OIIO_VERSION} -b Release-${OIIO_VERSION}
+    git checkout "tags/Release-${OIIO_VERSION}" -b "Release-${OIIO_VERSION}"
 fi
 
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
+cmake -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" \
       -DOIIO_BUILD_TOOLS=ON \
       -DOIIO_BUILD_TESTS=OFF \
       -DVERBOSE=ON \
-      -DPYTHON_VERSION=${PYTHON_VERSION} \
+      -DPYTHON_VERSION="${PYTHON_VERSION}" \
       -DBoost_NO_BOOST_CMAKE=ON \
       ../.
 make -j$(nproc)

--- a/scripts/vfx/build_openexr.sh
+++ b/scripts/vfx/build_openexr.sh
@@ -4,30 +4,30 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/openexr-${OPENEXR_VERSION}.tar.gz ]; then
-    curl --location https://github.com/AcademySoftwareFoundation/openexr/archive/v${OPENEXR_VERSION}.tar.gz -o $DOWNLOADS_DIR/openexr-${OPENEXR_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/openexr-${OPENEXR_VERSION}.tar.gz" ]; then
+    curl --location "https://github.com/AcademySoftwareFoundation/openexr/archive/v${OPENEXR_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/openexr-${OPENEXR_VERSION}.tar.gz"
 fi
 
-tar xf $DOWNLOADS_DIR/openexr-${OPENEXR_VERSION}.tar.gz
-cd openexr-${OPENEXR_VERSION}
+tar xf "$DOWNLOADS_DIR/openexr-${OPENEXR_VERSION}.tar.gz"
+cd "openexr-${OPENEXR_VERSION}"
 
 if [[ $OPENEXR_VERSION == 2.2* ]]; then
 
     cd IlmBase
     ./bootstrap
-    ./configure --prefix=${ASWF_INSTALL_PREFIX}
+    ./configure --prefix="${ASWF_INSTALL_PREFIX}"
     make -j$(nproc)
     make install
 
     cd ../OpenEXR
     ./bootstrap
-    ./configure --prefix=${ASWF_INSTALL_PREFIX}
+    ./configure --prefix="${ASWF_INSTALL_PREFIX}"
     make -j$(nproc)
     make install
 
     cd ../PyIlmBase
     ./bootstrap
-    ./configure --prefix=${ASWF_INSTALL_PREFIX}
+    ./configure --prefix="${ASWF_INSTALL_PREFIX}"
     make
     make install
 else
@@ -46,12 +46,12 @@ else
     mkdir build
     cd build
     cmake \
-        -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
-        -DOPENEXR_BUILD_PYTHON_LIBS=${BUILD_PYILMBASE} \
+        -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" \
+        -DOPENEXR_BUILD_PYTHON_LIBS="${BUILD_PYILMBASE}" \
         ..
     make -j$(nproc)
     make install
 fi
 
 cd ../..
-rm -rf openexr-${OPENEXR_VERSION}
+rm -rf "openexr-${OPENEXR_VERSION}"

--- a/scripts/vfx/build_opensubdiv.sh
+++ b/scripts/vfx/build_opensubdiv.sh
@@ -7,12 +7,12 @@ set -ex
 mkdir opensubdiv
 cd opensubdiv
 
-if [ ! -f $DOWNLOADS_DIR/opensubdiv-${OPENSUBDIV_VERSION}.tar.gz ]; then
-     curl --location https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${OPENSUBDIV_VERSION}.tar.gz -o $DOWNLOADS_DIR/opensubdiv-${OPENSUBDIV_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/opensubdiv-${OPENSUBDIV_VERSION}.tar.gz" ]; then
+     curl --location "https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${OPENSUBDIV_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/opensubdiv-${OPENSUBDIV_VERSION}.tar.gz"
 fi
 
-tar -zxf $DOWNLOADS_DIR/opensubdiv-${OPENSUBDIV_VERSION}.tar.gz
-cd OpenSubdiv-${OPENSUBDIV_VERSION}
+tar -zxf "$DOWNLOADS_DIR/opensubdiv-${OPENSUBDIV_VERSION}.tar.gz"
+cd "OpenSubdiv-${OPENSUBDIV_VERSION}"
 
 # Apply cmake patch https://github.com/PixarAnimationStudios/OpenSubdiv/pull/952
 cat <<EOF | patch -p1
@@ -42,15 +42,15 @@ mkdir build
 cd build
 
 cmake .. \
-      -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
+      -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" \
       -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda \
       -DOPENCL_INCLUDE_DIRS=/usr/local/cuda/include \
       -DOPENCL_LIBRARIES=/usr/local/cuda/lib64/libOpenCL.so \
-      -DTBB_LOCATION=${ASWF_INSTALL_PREFIX} \
-      -DPTEX_INCLUDE_DIR=${ASWF_INSTALL_PREFIX}/include \
-      -DPTEX_LOCATION=${ASWF_INSTALL_PREFIX} \
-      -DGLFW_LOCATION=${ASWF_INSTALL_PREFIX} \
-      -DGLEW_INCLUDE_DIR=${ASWF_INSTALL_PREFIX}/include \
+      -DTBB_LOCATION="${ASWF_INSTALL_PREFIX}" \
+      -DPTEX_INCLUDE_DIR="${ASWF_INSTALL_PREFIX}/include" \
+      -DPTEX_LOCATION="${ASWF_INSTALL_PREFIX}" \
+      -DGLFW_LOCATION="${ASWF_INSTALL_PREFIX}" \
+      -DGLEW_INCLUDE_DIR="${ASWF_INSTALL_PREFIX}/include" \
       -DNO_EXAMPLES=ON \
       -DNO_REGRESSION=1 \
       -DNO_DOC=1 \

--- a/scripts/vfx/build_openvdb.sh
+++ b/scripts/vfx/build_openvdb.sh
@@ -4,12 +4,12 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/openvdb-${OPENVDB_VERSION}.tar.gz ]; then
-     curl --location https://github.com/AcademySoftwareFoundation/openvdb/archive/v${OPENVDB_VERSION}.tar.gz -o $DOWNLOADS_DIR/openvdb-${OPENVDB_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/openvdb-${OPENVDB_VERSION}.tar.gz" ]; then
+     curl --location "https://github.com/AcademySoftwareFoundation/openvdb/archive/v${OPENVDB_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/openvdb-${OPENVDB_VERSION}.tar.gz"
 fi
 
-tar -zxf $DOWNLOADS_DIR/openvdb-${OPENVDB_VERSION}.tar.gz
-cd openvdb-${OPENVDB_VERSION}
+tar -zxf "$DOWNLOADS_DIR/openvdb-${OPENVDB_VERSION}.tar.gz"
+cd "openvdb-${OPENVDB_VERSION}"
 
 if [[ $OPENVDB_VERSION == 5* ]]; then
 cat <<EOF | patch -p1
@@ -33,13 +33,13 @@ mkdir build
 cd build
 
 cmake \
-    -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
-    -DOPENEXR_LOCATION=${ASWF_INSTALL_PREFIX} \
-    -DCPPUNIT_LOCATION=${ASWF_INSTALL_PREFIX} \
-    -DBLOSC_LOCATION=${ASWF_INSTALL_PREFIX} \
-    -DTBB_LOCATION=${ASWF_INSTALL_PREFIX} \
-    -DILMBASE_LOCATION=${ASWF_INSTALL_PREFIX} \
-    -DGLFW3_LOCATION=${ASWF_INSTALL_PREFIX} \
+    -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" \
+    -DOPENEXR_LOCATION="${ASWF_INSTALL_PREFIX}" \
+    -DCPPUNIT_LOCATION="${ASWF_INSTALL_PREFIX}" \
+    -DBLOSC_LOCATION="${ASWF_INSTALL_PREFIX}" \
+    -DTBB_LOCATION="${ASWF_INSTALL_PREFIX}" \
+    -DILMBASE_LOCATION="${ASWF_INSTALL_PREFIX}" \
+    -DGLFW3_LOCATION="${ASWF_INSTALL_PREFIX}" \
     -DUSE_GLFW3=ON \
     -DGLFW3_USE_STATIC_LIBS=ON \
     -DOPENVDB_BUILD_UNITTESTS=OFF \
@@ -52,4 +52,4 @@ make -j$(nproc)
 make install
 
 cd ../..
-rm -rf openvdb-${OPENVDB_VERSION}
+rm -rf "openvdb-${OPENVDB_VERSION}"

--- a/scripts/vfx/build_osl.sh
+++ b/scripts/vfx/build_osl.sh
@@ -4,17 +4,17 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/osl-${OSL_VERSION}.tar.gz ]; then
-    curl --location https://github.com/imageworks/OpenShadingLanguage/archive/Release-${OSL_VERSION}.tar.gz -o $DOWNLOADS_DIR/osl-${OSL_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/osl-${OSL_VERSION}.tar.gz" ]; then
+    curl --location "https://github.com/imageworks/OpenShadingLanguage/archive/Release-${OSL_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/osl-${OSL_VERSION}.tar.gz"
 fi
 
-tar -zxf $DOWNLOADS_DIR/osl-${OSL_VERSION}.tar.gz
-cd OpenShadingLanguage-Release-${OSL_VERSION}
+tar -zxf "$DOWNLOADS_DIR/osl-${OSL_VERSION}.tar.gz"
+cd "OpenShadingLanguage-Release-${OSL_VERSION}"
 
 mkdir build
 cd build
 
-cmake -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
+cmake -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" \
       -DBoost_USE_STATIC_LIBS=OFF \
       -DBUILD_SHARED_LIBS=ON \
       -DCMAKE_CXX_STANDARD=14 \
@@ -24,4 +24,4 @@ make -j$(nproc)
 make install
 
 cd ../..
-rm -rf OpenShadingLanguage-Release-${OSL_VERSION}
+rm -rf "OpenShadingLanguage-Release-${OSL_VERSION}"

--- a/scripts/vfx/build_otio.sh
+++ b/scripts/vfx/build_otio.sh
@@ -8,10 +8,10 @@ git clone https://github.com/PixarAnimationStudios/OpenTimelineIO.git
 cd OpenTimelineIO
 
 if [ "$OTIO_VERSION" != "latest" ]; then
-    git checkout tags/v${OTIO_VERSION} -b v${OTIO_VERSION}
+    git checkout "tags/v${OTIO_VERSION}" -b "v${OTIO_VERSION}"
 fi
 
-pip install --prefix=${ASWF_INSTALL_PREFIX} .
+pip install --prefix="${ASWF_INSTALL_PREFIX}" .
 
 cd ..
 rm -rf OpenTimelineIO

--- a/scripts/vfx/build_partio.sh
+++ b/scripts/vfx/build_partio.sh
@@ -4,19 +4,18 @@
 
 set -ex
 
-if [ ! -f $DOWNLOADS_DIR/partio-${PARTIO_VERSION}.tar.gz ]; then
-    curl --location https://github.com/wdas/partio/archive/v${PARTIO_VERSION}.tar.gz -o $DOWNLOADS_DIR/partio-${PARTIO_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/partio-${PARTIO_VERSION}.tar.gz" ]; then
+    curl --location "https://github.com/wdas/partio/archive/v${PARTIO_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/partio-${PARTIO_VERSION}.tar.gz"
 fi
 
-tar -zxf $DOWNLOADS_DIR/partio-${PARTIO_VERSION}.tar.gz
-cd partio-${PARTIO_VERSION}
+tar -zxf "$DOWNLOADS_DIR/partio-${PARTIO_VERSION}.tar.gz"
+cd "partio-${PARTIO_VERSION}"
 
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
-      ..
+cmake -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" ..
 make -j$(nproc)
 make install
 
 cd ../..
-rm -rf partio-${PARTIO_VERSION}
+rm -rf "partio-${PARTIO_VERSION}"

--- a/scripts/vfx/build_ptex.sh
+++ b/scripts/vfx/build_ptex.sh
@@ -14,21 +14,21 @@ else
     PTEX_TAG="v${PTEX_VERSION}"
 fi
 
-if [ ! -f $DOWNLOADS_DIR/ptex-${PTEX_VERSION}.tar.gz ]; then
-    curl --location http://github.com/wdas/ptex/archive/${PTEX_TAG}.tar.gz -o $DOWNLOADS_DIR/ptex-${PTEX_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/ptex-${PTEX_VERSION}.tar.gz" ]; then
+    curl --location "http://github.com/wdas/ptex/archive/${PTEX_TAG}.tar.gz" -o "$DOWNLOADS_DIR/ptex-${PTEX_VERSION}.tar.gz"
 fi
 
-tar -zxf $DOWNLOADS_DIR/ptex-${PTEX_VERSION}.tar.gz
+tar -zxf "$DOWNLOADS_DIR/ptex-${PTEX_VERSION}.tar.gz"
 
 if [ $PTEX_VERSION = "2.3.2" ]; then
     # rename folder to expected name
-    mv ptex-${PTEX_TAG} ptex-${PTEX_VERSION}
+    mv "ptex-${PTEX_TAG}" "ptex-${PTEX_VERSION}"
 fi
 
-cd ptex-${PTEX_VERSION}
+cd "ptex-${PTEX_VERSION}"
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} ..
+cmake -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" ..
 make -j$(nproc)
 make install
 

--- a/scripts/vfx/build_usd.sh
+++ b/scripts/vfx/build_usd.sh
@@ -6,12 +6,12 @@ set -ex
 
 pip install jinja2 PyOpenGL
 
-if [ ! -f $DOWNLOADS_DIR/usd-${USD_VERSION}.tar.gz ]; then
-     curl --location https://github.com/PixarAnimationStudios/USD/archive/v${USD_VERSION}.tar.gz -o $DOWNLOADS_DIR/usd-${USD_VERSION}.tar.gz
+if [ ! -f "$DOWNLOADS_DIR/usd-${USD_VERSION}.tar.gz" ]; then
+     curl --location "https://github.com/PixarAnimationStudios/USD/archive/v${USD_VERSION}.tar.gz" -o "$DOWNLOADS_DIR/usd-${USD_VERSION}.tar.gz"
 fi
 
-tar -zxf $DOWNLOADS_DIR/usd-${USD_VERSION}.tar.gz
-cd USD-${USD_VERSION}
+tar -zxf "$DOWNLOADS_DIR/usd-${USD_VERSION}.tar.gz"
+cd "USD-${USD_VERSION}"
 
 if [[ $USD_VERSION == 19.* ]]; then
      VT_SRC_FOLDER=base/lib/vt
@@ -19,7 +19,7 @@ else
      VT_SRC_FOLDER=base/vt
 fi
 
-touch pxr/${VT_SRC_FOLDER}/devtoolset6Workaround.cpp
+touch "pxr/${VT_SRC_FOLDER}/devtoolset6Workaround.cpp"
 echo '#if (__GNUC__ >= 6)
 #include <cstdlib>
 #pragma weak __cxa_throw_bad_array_new_length
@@ -27,7 +27,7 @@ extern "C" void __cxa_throw_bad_array_new_length()
 {
  abort();
 }
-#endif' >> pxr/${VT_SRC_FOLDER}/devtoolset6Workaround.cpp
+#endif' >> "pxr/${VT_SRC_FOLDER}/devtoolset6Workaround.cpp"
 
 patch -p1 <<EOF
 diff --git a/pxr/${VT_SRC_FOLDER}/CMakeLists.txt b/pxr/${VT_SRC_FOLDER}/CMakeLists.txt
@@ -56,14 +56,14 @@ else
 fi
 
 cmake \
-     -DCMAKE_INSTALL_PREFIX=${ASWF_INSTALL_PREFIX} \
-     -DOPENEXR_LOCATION=${ASWF_INSTALL_PREFIX} \
-     -DCPPUNIT_LOCATION=${ASWF_INSTALL_PREFIX} \
-     -DBLOSC_LOCATION=${ASWF_INSTALL_PREFIX} \
-     -DTBB_LOCATION=${ASWF_INSTALL_PREFIX} \
-     -DILMBASE_LOCATION=${ASWF_INSTALL_PREFIX} \
+     -DCMAKE_INSTALL_PREFIX="${ASWF_INSTALL_PREFIX}" \
+     -DOPENEXR_LOCATION="${ASWF_INSTALL_PREFIX}" \
+     -DCPPUNIT_LOCATION="${ASWF_INSTALL_PREFIX}" \
+     -DBLOSC_LOCATION="${ASWF_INSTALL_PREFIX}" \
+     -DTBB_LOCATION="${ASWF_INSTALL_PREFIX}" \
+     -DILMBASE_LOCATION="${ASWF_INSTALL_PREFIX}" \
      -DPXR_BUILD_TESTS=OFF \
-     -DUSD_ROOT_DIR=$ASWF_INSTALL_PREFIX \
+     -DUSD_ROOT_DIR="${ASWF_INSTALL_PREFIX}" \
      -DPXR_BUILD_ALEMBIC_PLUGIN=OFF \
      -DPXR_BUILD_MAYA_PLUGIN=FALSE \
      ${USD_EXTRA_ARGS} \
@@ -74,4 +74,4 @@ make install
 
 cd ../..
 
-rm -rf USD-${USD_VERSION}
+rm -rf "USD-${USD_VERSION}"


### PR DESCRIPTION
1. Not sure what your stand is on whitespace changes. I'm happy to revert those.
2. But using double quotes around paths seems like a good idea - if e.g. $DOWNLOAD_DIR was changed to a path with a space in it, it would break.
3. Using quotes here is a bit too much, so I did no change it: `make -j$(nproc)`
4. In cases like `sh bootstrap.sh ${BOOTSTRAP_ARGS}`, there are intentionally no quotes I suppose.
5. Not sure about the following in `scripts\base\build_boost.sh`:

       BOOST_MAJOR_MINOR=$(echo "${BOOST_VERSION}" | cut -d. -f-2)

   > Possible misspelling: BOOST_VERSION may not be assigned, but BOOST_VERSION_U is (SC2153)

6. In `scripts\common\install_sonar.sh` there are two warnings:

   > Useless echo? Instead of 'echo $(cmd)', just use 'cmd' (SC2005)

   Does the pattern serve any particular purpose? `echo $(sonar-scanner --help)`

7. I substituted `` `cmd` `` by `$(cmd)` as suggested
8. `CI_COMMON_VERSION` was set twice in `ci-common/Dockerfile` and I combined the two ENVs