### PR TITLE
Post-release cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 * All CI images (except `ci-common`) are now automatically generated from a template and come with a `README.md` (also templated) containing all the current package version numbers.
 * All package versions have been moved from version bash scripts into the `versions.yaml` file, which enables the tagging of the image with these versions.
 * VFX 2021 images are now built against CUDA-11.1.
+* Update SonarQube client version 4.5.0.2216 (upgraded from 3.3.0.1492)
 
 ### New CI Packages:
 * `ci-package-clang:1-clang6.2`, `ci-package-clang:1-clang7.2`, `ci-package-clang:1-clang8.2`, `ci-package-clang:1-clang9.2`, `ci-package-clang:1-clang10.2`, `ci-package-clang:2-clang10.2`, `ci-package-clang:2-clang11.2`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -365,3 +365,44 @@ aswfdocker release -n aswftesting/ci-package-xyz:2021 --sha `git rev-parse HEAD`
 * Create the Pull Request with these changes
 
 Check [#66](https://github.com/AcademySoftwareFoundation/aswf-docker/pull/66) for an example.
+
+
+### Example of a large re-release of all images:
+```
+# Common packages
+aswfdocker release -t PACKAGE -g common -v 1 -v 2 --target ninja --docker-org aswf -m "RELEASE_NOTES!"
+aswfdocker release -t PACKAGE -g common -v 1-clang6 -v 1-clang7 -v 1-clang8 -v 1-clang9 -v 1-clang10 -v 2-clang10 -v 2-clang11 --target clang --docker-org aswf -m "RELEASE_NOTES!"
+# Wait for clang builds to finish (from 2 to 3 hours!)
+
+# ci-common needs to be built before base packages can be built
+aswfdocker release -t IMAGE -g common -v 1-clang6 -v 1-clang7 -v 1-clang8 -v 1-clang9 -v 1-clang10 -v 2-clang10 -v 2-clang11 --docker-org aswf -m "RELEASE_NOTES!"
+
+# Base packages
+aswfdocker release -t PACKAGE -g base1 -v 2018 -v 2019 -v 2020 -v 2021 --docker-org aswf -m "RELEASE_NOTES!"
+aswfdocker release -t PACKAGE -g base2 -v 2018 -v 2019 -v 2020 -v 2021 --docker-org aswf -m "RELEASE_NOTES!"
+# Wait for Qt builds to finish (2-6 hours!)
+
+# Usually some Qt build will fail as too big and too slow for free GitHub actions... So here's how to build qt locally:
+aswfdocker --repo-uri https://github.com/AcademySoftwareFoundation/aswf-docker --source-branch refs/heads/master --verbose build -n aswf/ci-package-qt
+:2021
+docker push aswf/ci-package-qt:2021
+docker push aswf/ci-package-qt:2021-5.12.8
+docker push aswf/ci-package-qt:preview
+docker push aswf/ci-package-qt:2021.1
+
+# Once all Qt are out, release PySide packages
+aswfdocker release -t PACKAGE -g base3 -v 2018 -v 2019 -v 2020 -v 2021 --docker-org aswf -m "RELEASE_NOTES!"
+
+
+# Wait for all Qt and Pyside builds to finish, then build downstream packages:
+# VFX packages
+aswfdocker release -t PACKAGE -g vfx1 -v 2018 -v 2019 -v 2020 -v 2021 --docker-org aswf -m "RELEASE_NOTES!"
+aswfdocker release -t PACKAGE -g vfx2 -v 2018 -v 2019 -v 2020 -v 2021 --docker-org aswf -m "RELEASE_NOTES!"
+
+
+# Finally build the CI images
+aswfdocker release -t IMAGE -g base -v 2018 -v 2019 -v 2020 -v 2021 --docker-org aswf -m "RELEASE_NOTES!"
+aswfdocker release -t IMAGE -g vfx1 -v 2018 -v 2019 -v 2020 -v 2021 --docker-org aswf -m "RELEASE_NOTES!"
+aswfdocker release -t IMAGE -g vfx2 -v 2018 -v 2019 -v 2020 -v 2021 --docker-org aswf -m "RELEASE_NOTES!"
+aswfdocker release -t IMAGE -g vfx3 -v 2018-clang7 -v 2019-clang6 -v 2019-clang7 -v 2019-clang8 -v 2019-clang9 -v 2020-clang7 -v 2021-clang10 -v 2021-clang11 --docker-org aswf -m "RELEASE_NOTES!"
+```

--- a/packages/vfx1/Dockerfile
+++ b/packages/vfx1/Dockerfile
@@ -8,10 +8,14 @@ ARG CI_COMMON_VERSION
 ARG CLANG_MAJOR_VERSION
 ARG VFXPLATFORM_VERSION
 
+ARG BOOST_VERSION
+ARG CMAKE_VERSION
+ARG CPPUNIT_VERSION
+ARG GLEW_VERSION
+ARG GLFW_VERSION
 ARG PYTHON_VERSION
 ARG PYTHON_VERSION_MAJOR_MINOR
-ARG CMAKE_VERSION
-ARG BOOST_VERSION
+ARG TBB_VERSION
 
 ARG ALEMBIC_VERSION
 ARG BLOSC_VERSION
@@ -25,6 +29,10 @@ ARG OPENEXR_VERSION
 FROM ${ASWF_ORG}/ci-package-cmake:${VFXPLATFORM_VERSION}-${CMAKE_VERSION} as ci-package-cmake-external
 FROM ${ASWF_ORG}/ci-package-python:${VFXPLATFORM_VERSION}-${PYTHON_VERSION} as ci-package-python-external
 FROM ${ASWF_ORG}/ci-package-boost:${VFXPLATFORM_VERSION}-${BOOST_VERSION} as ci-package-boost-external
+FROM ${ASWF_ORG}/ci-package-glew:${VFXPLATFORM_VERSION}-${GLEW_VERSION} as ci-package-glew-external
+FROM ${ASWF_ORG}/ci-package-tbb:${VFXPLATFORM_VERSION}-${TBB_VERSION} as ci-package-tbb-external
+FROM ${ASWF_ORG}/ci-package-cppunit:${VFXPLATFORM_VERSION}-${CPPUNIT_VERSION} as ci-package-cppunit-external
+FROM ${ASWF_ORG}/ci-package-glfw:${VFXPLATFORM_VERSION}-${GLFW_VERSION} as ci-package-glfw-external
 
 #################### ci-centos7-gl-packages ####################
 FROM ${ASWF_ORG}/ci-common:${CI_COMMON_VERSION}-clang${CLANG_MAJOR_VERSION} as ci-base-builder
@@ -285,3 +293,55 @@ RUN --mount=type=cache,target=/tmp/ccache \
     /tmp/build_osl.sh && \
     /tmp/copy_new_files.sh && \
     ccache --show-stats
+
+
+#################### ci-openvdb-builder ####################
+FROM ci-openexr-builder as ci-openvdb-builder
+
+ARG OPENVDB_VERSION
+ENV OPENVDB_VERSION=${OPENVDB_VERSION}
+
+COPY ../scripts/vfx/build_openvdb.sh \
+     /tmp/
+
+COPY --from=ci-package-glew-external /. /usr/local/
+COPY --from=ci-package-tbb-external /. /usr/local/
+COPY --from=ci-package-cppunit-external /. /usr/local/
+COPY --from=ci-package-glfw-external /. /usr/local/
+
+COPY --from=ci-package-blosc /. /usr/local/
+
+RUN --mount=type=cache,target=/tmp/ccache \
+     --mount=type=cache,sharing=private,target=/tmp/downloads \
+     /tmp/before_build.sh && \
+     /tmp/build_openvdb.sh && \
+     /tmp/copy_new_files.sh && \
+     ccache --show-stats
+
+
+#################### ci-package-openvdb ####################
+FROM scratch as ci-package-openvdb
+
+ARG ASWF_ORG
+ARG CI_COMMON_VERSION
+ARG DTS_VERSION
+ARG OPENVDB_VERSION
+ARG VFXPLATFORM_VERSION
+
+LABEL org.opencontainers.image.name="$ASWF_ORG/ci-package-openvdb"
+LABEL org.opencontainers.image.title="OpenVDB package built for ASWF docker images"
+LABEL org.opencontainers.image.description="OpenVDB headers and binaries to be installed in ASWF docker images"
+LABEL org.opencontainers.image.authors="Built by aswf.io CI Working Group"
+LABEL org.opencontainers.image.vendor="AcademySoftwareFoundation"
+LABEL org.opencontainers.image.url="https://github.com/AcademySoftwareFoundation/openvdb"
+LABEL org.opencontainers.image.source="https://github.com/AcademySoftwareFoundation/aswf-docker/blob/master/packages/Dockerfile"
+LABEL org.opencontainers.image.version="${OPENVDB_VERSION}"
+LABEL org.opencontainers.image.licenses="MPL-2.0"
+LABEL io.aswf.docker.versions.ci-common="${CI_COMMON_VERSION}"
+LABEL io.aswf.docker.versions.vfx-platform="${VFXPLATFORM_VERSION}"
+LABEL io.aswf.docker.versions.dts="${DTS_VERSION}"
+LABEL io.aswf.docker.versions.openvdb="${OPENVDB_VERSION}"
+
+COPY --from=ci-openvdb-builder /package/. /
+
+

--- a/packages/vfx2/Dockerfile
+++ b/packages/vfx2/Dockerfile
@@ -246,56 +246,6 @@ LABEL io.aswf.docker.versions.opensubdiv="${OPENSUBDIV_VERSION}"
 COPY --from=ci-opensubdiv-builder /package/. /
 
 
-#################### ci-openvdb-builder ####################
-FROM ci-base-builder as ci-openvdb-builder
-
-ARG OPENVDB_VERSION
-ENV OPENVDB_VERSION=${OPENVDB_VERSION}
-
-COPY ../scripts/vfx/build_openvdb.sh \
-     /tmp/
-
-COPY --from=ci-package-openexr-external /. /usr/local/
-COPY --from=ci-package-glew-external /. /usr/local/
-COPY --from=ci-package-tbb-external /. /usr/local/
-COPY --from=ci-package-cppunit-external /. /usr/local/
-COPY --from=ci-package-glfw-external /. /usr/local/
-COPY --from=ci-package-blosc-external /. /usr/local/
-
-RUN --mount=type=cache,target=/tmp/ccache \
-     --mount=type=cache,sharing=private,target=/tmp/downloads \
-     /tmp/before_build.sh && \
-     /tmp/build_openvdb.sh && \
-     /tmp/copy_new_files.sh && \
-     ccache --show-stats
-
-
-#################### ci-package-openvdb ####################
-FROM scratch as ci-package-openvdb
-
-ARG ASWF_ORG
-ARG CI_COMMON_VERSION
-ARG DTS_VERSION
-ARG OPENVDB_VERSION
-ARG VFXPLATFORM_VERSION
-
-LABEL org.opencontainers.image.name="$ASWF_ORG/ci-package-openvdb"
-LABEL org.opencontainers.image.title="OpenVDB package built for ASWF docker images"
-LABEL org.opencontainers.image.description="OpenVDB headers and binaries to be installed in ASWF docker images"
-LABEL org.opencontainers.image.authors="Built by aswf.io CI Working Group"
-LABEL org.opencontainers.image.vendor="AcademySoftwareFoundation"
-LABEL org.opencontainers.image.url="https://github.com/AcademySoftwareFoundation/openvdb"
-LABEL org.opencontainers.image.source="https://github.com/AcademySoftwareFoundation/aswf-docker/blob/master/packages/Dockerfile"
-LABEL org.opencontainers.image.version="${OPENVDB_VERSION}"
-LABEL org.opencontainers.image.licenses="MPL-2.0"
-LABEL io.aswf.docker.versions.ci-common="${CI_COMMON_VERSION}"
-LABEL io.aswf.docker.versions.vfx-platform="${VFXPLATFORM_VERSION}"
-LABEL io.aswf.docker.versions.dts="${DTS_VERSION}"
-LABEL io.aswf.docker.versions.openvdb="${OPENVDB_VERSION}"
-
-COPY --from=ci-openvdb-builder /package/. /
-
-
 #################### ci-usd-builder ####################
 FROM ci-opensubdiv-builder as ci-usd-builder
 

--- a/python/aswfdocker/dockergen.py
+++ b/python/aswfdocker/dockergen.py
@@ -69,10 +69,11 @@ class DockerGen:
     def push_overview(self, docker_org, token):
         _, readme = self._render_readme()
 
+        description = self.image_data["title"] + "\n" + self.image_data["description"]
+        if len(description) > 99:
+            description = description[:96] + "..."
         body = {
-            "description": self.image_data["title"]
-            + "\n"
-            + self.image_data["description"],
+            "description": description,
             "full_description": readme,
         }
         url = (
@@ -82,4 +83,7 @@ class DockerGen:
         response = requests.patch(
             url, json=body, headers={"Authorization": f"JWT {token}"},
         )
-        return response.status_code == 200
+        if response.status_code == 200:
+            return True
+        logger.error("Failed to update description: %s", response.json())
+        return False

--- a/python/aswfdocker/tests/test_builder.py
+++ b/python/aswfdocker/tests/test_builder.py
@@ -82,7 +82,7 @@ class TestBuilder(unittest.TestCase):
         b = builder.Builder(
             self.build_info,
             groupinfo.GroupInfo(
-                names=["vfx1"],
+                names=["vfx3"],
                 versions=["2019-clang9"],
                 type_=constants.ImageType.IMAGE,
                 targets=["openvdb"],

--- a/versions.yaml
+++ b/versions.yaml
@@ -392,14 +392,6 @@ ci-images:
     - "2019.7"
     - "2020.7"
     - "2021.3"
-  openvdb:
-    - "2018-clang7.7"
-    - "2019-clang6.7"
-    - "2019-clang7.7"
-    - "2019-clang8.7"
-    - "2019-clang9.7"
-    - "2020-clang7.7"
-    - "2021-clang10.3"
   ocio:
     - "2018.8"
     - "2019.8"
@@ -414,6 +406,10 @@ ci-images:
     - "2019.8"
     - "2020.7"
     - "2021.3"
+  otio:
+    - "2019.2"
+    - "2020.2"
+    - "2021.2"
   osl:
     - "2018-clang7.3"
     - "2019-clang6.3"
@@ -424,10 +420,14 @@ ci-images:
     - "2020-clang7.3"
     - "2021-clang10.3"
     - "2021-clang11.3"
-  otio:
-    - "2019.2"
-    - "2020.2"
-    - "2021.2"
+  openvdb:
+    - "2018-clang7.7"
+    - "2019-clang6.7"
+    - "2019-clang7.7"
+    - "2019-clang8.7"
+    - "2019-clang9.7"
+    - "2020-clang7.7"
+    - "2021-clang10.3"
   vfxall:
     - "2019-clang6.11"
     - "2019-clang7.11"
@@ -460,9 +460,9 @@ groups:
         - ocio
         - oiio
         - openexr
+        - openvdb
       vfx2: 
         - opensubdiv
-        - openvdb
         - osl
         - otio
         - partio
@@ -477,13 +477,13 @@ groups:
       vfx1:
         - opencue
         - openexr
-        - openvdb
       vfx2:
         - ocio
-        - osl
         - otio
         - usd
       vfx3:
+        - osl
+        - openvdb
         - vfxall
 
 package_data:


### PR DESCRIPTION
Found out the hard way that some short descriptions were a bit too long for DockerHub... So I'm now truncate the DockerHub description to the allowed maximum of 100 chars.
Also re-organised some groups to facilitate release, and added my release steps to the contributing notes.