### PR TITLE
Fixed missing packages in ci-osl

### DIFF
--- a/ci-osl/Dockerfile
+++ b/ci-osl/Dockerfile
@@ -10,12 +10,11 @@ ARG ASWF_CLANG_MAJOR_VERSION
 
 ARG ASWF_BOOST_VERSION
 ARG ASWF_CMAKE_VERSION
-ARG ASWF_CPPUNIT_VERSION
-ARG ASWF_GLFW_VERSION
 ARG ASWF_PYTHON_VERSION
-ARG ASWF_TBB_VERSION
+ARG ASWF_QT_VERSION
 ARG ASWF_OPENEXR_VERSION
-ARG ASWF_BLOSC_VERSION
+ARG ASWF_OIIO_VERSION
+ARG ASWF_PARTIO_VERSION
 ARG ASWF_NUMPY_VERSION
 ARG ASWF_VFXPLATFORM_VERSION
 ARG ASWF_PYTHON_MAJOR_MINOR_VERSION
@@ -23,12 +22,11 @@ ARG ASWF_PYTHON_MAJOR_MINOR_VERSION
 
 FROM ${ASWF_PKG_ORG}/ci-package-boost:$ASWF_VFXPLATFORM_VERSION-$ASWF_BOOST_VERSION as ci-package-boost
 FROM ${ASWF_PKG_ORG}/ci-package-cmake:$ASWF_VFXPLATFORM_VERSION-$ASWF_CMAKE_VERSION as ci-package-cmake
-FROM ${ASWF_PKG_ORG}/ci-package-cppunit:$ASWF_VFXPLATFORM_VERSION-$ASWF_CPPUNIT_VERSION as ci-package-cppunit
-FROM ${ASWF_PKG_ORG}/ci-package-glfw:$ASWF_VFXPLATFORM_VERSION-$ASWF_GLFW_VERSION as ci-package-glfw
 FROM ${ASWF_PKG_ORG}/ci-package-python:$ASWF_VFXPLATFORM_VERSION-$ASWF_PYTHON_VERSION as ci-package-python
-FROM ${ASWF_PKG_ORG}/ci-package-tbb:$ASWF_VFXPLATFORM_VERSION-$ASWF_TBB_VERSION as ci-package-tbb
+FROM ${ASWF_PKG_ORG}/ci-package-qt:$ASWF_VFXPLATFORM_VERSION-$ASWF_QT_VERSION as ci-package-qt
 FROM ${ASWF_PKG_ORG}/ci-package-openexr:$ASWF_VFXPLATFORM_VERSION-$ASWF_OPENEXR_VERSION as ci-package-openexr
-FROM ${ASWF_PKG_ORG}/ci-package-blosc:$ASWF_VFXPLATFORM_VERSION-$ASWF_BLOSC_VERSION as ci-package-blosc
+FROM ${ASWF_PKG_ORG}/ci-package-oiio:$ASWF_VFXPLATFORM_VERSION-$ASWF_OIIO_VERSION as ci-package-oiio
+FROM ${ASWF_PKG_ORG}/ci-package-partio:$ASWF_VFXPLATFORM_VERSION-$ASWF_PARTIO_VERSION as ci-package-partio
 FROM ${ASWF_ORG}/ci-common:${CI_COMMON_VERSION}-clang${ASWF_CLANG_MAJOR_VERSION} as ci-osl
 
 
@@ -37,12 +35,11 @@ ARG ASWF_VERSION
 
 ARG ASWF_BOOST_VERSION
 ARG ASWF_CMAKE_VERSION
-ARG ASWF_CPPUNIT_VERSION
-ARG ASWF_GLFW_VERSION
 ARG ASWF_PYTHON_VERSION
-ARG ASWF_TBB_VERSION
+ARG ASWF_QT_VERSION
 ARG ASWF_OPENEXR_VERSION
-ARG ASWF_BLOSC_VERSION
+ARG ASWF_OIIO_VERSION
+ARG ASWF_PARTIO_VERSION
 ARG ASWF_NUMPY_VERSION
 ARG ASWF_VFXPLATFORM_VERSION
 ARG ASWF_PYTHON_MAJOR_MINOR_VERSION
@@ -50,7 +47,7 @@ ARG ASWF_PYTHON_MAJOR_MINOR_VERSION
 
 LABEL org.opencontainers.image.name="$ASWF_ORG/ci-osl"
 LABEL org.opencontainers.image.title="OpenShadingLanguage CI Docker Image"
-LABEL org.opencontainers.image.description="Contains: python, boost, tbb, OpenEXR, Blosc and other OpenShadingLanguage upstream dependencies\
+LABEL org.opencontainers.image.description="Contains: python, boost, Qt, OpenEXR, OpenImageIO, PartIO and other OpenShadingLanguage upstream dependencies\
 Warning: this image does *not* contain OpenShadingLanguage itself as it is used to *build* OpenShadingLanguage!\
 "
 LABEL org.opencontainers.image.url="http://aswf.io/"
@@ -63,12 +60,11 @@ LABEL com.vfxplatform.version="${ASWF_VFXPLATFORM_VERSION}"
 
 LABEL io.aswf.docker.versions.boost="$ASWF_BOOST_VERSION"
 LABEL io.aswf.docker.versions.cmake="$ASWF_CMAKE_VERSION"
-LABEL io.aswf.docker.versions.cppunit="$ASWF_CPPUNIT_VERSION"
-LABEL io.aswf.docker.versions.glfw="$ASWF_GLFW_VERSION"
 LABEL io.aswf.docker.versions.python="$ASWF_PYTHON_VERSION"
-LABEL io.aswf.docker.versions.tbb="$ASWF_TBB_VERSION"
+LABEL io.aswf.docker.versions.qt="$ASWF_QT_VERSION"
 LABEL io.aswf.docker.versions.openexr="$ASWF_OPENEXR_VERSION"
-LABEL io.aswf.docker.versions.blosc="$ASWF_BLOSC_VERSION"
+LABEL io.aswf.docker.versions.oiio="$ASWF_OIIO_VERSION"
+LABEL io.aswf.docker.versions.partio="$ASWF_PARTIO_VERSION"
 LABEL io.aswf.docker.versions.numpy="$ASWF_NUMPY_VERSION"
 LABEL io.aswf.docker.versions.vfxplatform="$ASWF_VFXPLATFORM_VERSION"
 
@@ -79,12 +75,11 @@ ENV VFXPLATFORM_VERSION=${ASWF_VFXPLATFORM_VERSION}
 
 ENV ASWF_BOOST_VERSION=$ASWF_BOOST_VERSION
 ENV ASWF_CMAKE_VERSION=$ASWF_CMAKE_VERSION
-ENV ASWF_CPPUNIT_VERSION=$ASWF_CPPUNIT_VERSION
-ENV ASWF_GLFW_VERSION=$ASWF_GLFW_VERSION
 ENV ASWF_PYTHON_VERSION=$ASWF_PYTHON_VERSION
-ENV ASWF_TBB_VERSION=$ASWF_TBB_VERSION
+ENV ASWF_QT_VERSION=$ASWF_QT_VERSION
 ENV ASWF_OPENEXR_VERSION=$ASWF_OPENEXR_VERSION
-ENV ASWF_BLOSC_VERSION=$ASWF_BLOSC_VERSION
+ENV ASWF_OIIO_VERSION=$ASWF_OIIO_VERSION
+ENV ASWF_PARTIO_VERSION=$ASWF_PARTIO_VERSION
 ENV ASWF_NUMPY_VERSION=$ASWF_NUMPY_VERSION
 ENV ASWF_VFXPLATFORM_VERSION=$ASWF_VFXPLATFORM_VERSION
 ENV ASWF_PYTHON_MAJOR_MINOR_VERSION=$ASWF_PYTHON_MAJOR_MINOR_VERSION
@@ -92,12 +87,11 @@ ENV ASWF_PYTHON_MAJOR_MINOR_VERSION=$ASWF_PYTHON_MAJOR_MINOR_VERSION
 
 COPY --from=ci-package-boost /. /usr/local/
 COPY --from=ci-package-cmake /. /usr/local/
-COPY --from=ci-package-cppunit /. /usr/local/
-COPY --from=ci-package-glfw /. /usr/local/
 COPY --from=ci-package-python /. /usr/local/
-COPY --from=ci-package-tbb /. /usr/local/
+COPY --from=ci-package-qt /. /usr/local/
 COPY --from=ci-package-openexr /. /usr/local/
-COPY --from=ci-package-blosc /. /usr/local/
+COPY --from=ci-package-oiio /. /usr/local/
+COPY --from=ci-package-partio /. /usr/local/
 COPY ci-osl/README.md ci-osl/image.yaml /usr/local/aswf/
 
 

--- a/ci-osl/README.md
+++ b/ci-osl/README.md
@@ -11,7 +11,7 @@ See [aswf.io](https://aswf.io) and [aswf-docker](https://github.com/AcademySoftw
 
 ## OpenShadingLanguage CI Docker Image
 
-Contains: python, boost, tbb, OpenEXR, Blosc and other OpenShadingLanguage upstream dependencies
+Contains: python, boost, Qt, OpenEXR, OpenImageIO, PartIO and other OpenShadingLanguage upstream dependencies
 Warning: this image does *not* contain OpenShadingLanguage itself as it is used to *build* OpenShadingLanguage!
 
 
@@ -21,12 +21,11 @@ Warning: this image does *not* contain OpenShadingLanguage itself as it is used 
 Contains:
 * boost-1.61.0
 * cmake-3.9.4
-* cppunit-1.14.0
-* glfw-3.1.2
 * python-2.7.15
-* tbb-2017_U6
+* qt-5.6.1
 * openexr-2.2.1
-* blosc-1.5.0
+* oiio-2.0.8
+* partio-1.10.1
 * numpy-1.14
 * vfxplatform-2018
 
@@ -34,12 +33,11 @@ Contains:
 Contains:
 * boost-1.66.0
 * cmake-3.12.4
-* cppunit-1.14.0
-* glfw-3.1.2
 * python-2.7.15
-* tbb-2018
+* qt-5.12.6
 * openexr-2.3.0
-* blosc-1.5.0
+* oiio-2.0.8
+* partio-1.10.1
 * numpy-1.14
 * vfxplatform-2019
 
@@ -47,12 +45,11 @@ Contains:
 Contains:
 * boost-1.66.0
 * cmake-3.12.4
-* cppunit-1.14.0
-* glfw-3.1.2
 * python-2.7.15
-* tbb-2018
+* qt-5.12.6
 * openexr-2.3.0
-* blosc-1.5.0
+* oiio-2.0.8
+* partio-1.10.1
 * numpy-1.14
 * vfxplatform-2019
 
@@ -60,12 +57,11 @@ Contains:
 Contains:
 * boost-1.66.0
 * cmake-3.12.4
-* cppunit-1.14.0
-* glfw-3.1.2
 * python-2.7.15
-* tbb-2018
+* qt-5.12.6
 * openexr-2.3.0
-* blosc-1.5.0
+* oiio-2.0.8
+* partio-1.10.1
 * numpy-1.14
 * vfxplatform-2019
 
@@ -73,12 +69,11 @@ Contains:
 Contains:
 * boost-1.66.0
 * cmake-3.12.4
-* cppunit-1.14.0
-* glfw-3.1.2
 * python-2.7.15
-* tbb-2018
+* qt-5.12.6
 * openexr-2.3.0
-* blosc-1.5.0
+* oiio-2.0.8
+* partio-1.10.1
 * numpy-1.14
 * vfxplatform-2019
 
@@ -86,12 +81,11 @@ Contains:
 Contains:
 * boost-1.66.0
 * cmake-3.12.4
-* cppunit-1.14.0
-* glfw-3.1.2
 * python-2.7.15
-* tbb-2018
+* qt-5.12.6
 * openexr-2.3.0
-* blosc-1.5.0
+* oiio-2.0.8
+* partio-1.10.1
 * numpy-1.14
 * vfxplatform-2019
 
@@ -99,12 +93,11 @@ Contains:
 Contains:
 * boost-1.70.0
 * cmake-3.18.4
-* cppunit-1.15.1
-* glfw-3.1.2
 * python-3.7.3
-* tbb-2019_U6
+* qt-5.12.6
 * openexr-2.4.0
-* blosc-1.5.0
+* oiio-2.1.13.0
+* partio-1.10.1
 * numpy-1.16
 * vfxplatform-2020
 
@@ -112,12 +105,11 @@ Contains:
 Contains:
 * boost-1.70.0
 * cmake-3.18.4
-* cppunit-1.15.1
-* glfw-3.1.2
 * python-3.7.3
-* tbb-2019_U6
+* qt-5.12.8
 * openexr-2.4.0
-* blosc-1.5.0
+* oiio-2.1.13.0
+* partio-1.13.0
 * numpy-1.16
 * vfxplatform-2021
 
@@ -125,12 +117,11 @@ Contains:
 Contains:
 * boost-1.70.0
 * cmake-3.18.4
-* cppunit-1.15.1
-* glfw-3.1.2
 * python-3.7.3
-* tbb-2019_U6
+* qt-5.12.8
 * openexr-2.4.0
-* blosc-1.5.0
+* oiio-2.1.13.0
+* partio-1.13.0
 * numpy-1.16
 * vfxplatform-2021
 

--- a/ci-osl/image.yaml
+++ b/ci-osl/image.yaml
@@ -1,17 +1,16 @@
 name: "osl"
 title: "OpenShadingLanguage CI Docker Image"
 description: |
-  Contains: python, boost, tbb, OpenEXR, Blosc and other OpenShadingLanguage upstream dependencies
+  Contains: python, boost, Qt, OpenEXR, OpenImageIO, PartIO and other OpenShadingLanguage upstream dependencies
   Warning: this image does *not* contain OpenShadingLanguage itself as it is used to *build* OpenShadingLanguage!
 packages:
   - boost
   - cmake
-  - cppunit
-  - glfw
   - python
-  - tbb
+  - qt
   - openexr
-  - blosc
+  - oiio
+  - partio
 implicit_packages:
   - numpy
   - vfxplatform


### PR DESCRIPTION
Unfortunately `ci-osl` sustained some copy-paste damage in the last update... this should fix it!