### PR TITLE
Use conan aliases

### DIFF
--- a/packages/conan/recipes/README.md
+++ b/packages/conan/recipes/README.md
@@ -5,3 +5,9 @@ but with quite a few modifications to allow the VFX versions to build, and with 
 ASWF-made packages and avoid ABI mixes with the Conan Center packages.
 
 As the Conan Center Index is MIT licensed the whole subfolder here is also MIT licensed for consistency.
+
+## Adding new Conan packages
+
+Follow the great instructions there: [Conan Center Index - How to add Packages](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md).
+
+Then ensure the ASWF-specific settings are added in the `conanfile.py` such as: `python`, `devtoolset`, `ci_common` and `vfx_platform`.

--- a/packages/conan/recipes/alembic/conanfile.py
+++ b/packages/conan/recipes/alembic/conanfile.py
@@ -25,20 +25,12 @@ class AlembicConan(ConanFile):
     _source_subfolder = "source_subfolder"
 
     def requirements(self):
-        self.requires(
-            f"python/{os.environ['ASWF_PYTHON_VERSION']}@{self.user}/{self.channel}"
-        )
-        self.requires(
-            f"boost/{os.environ['ASWF_BOOST_VERSION']}@{self.user}/{self.channel}"
-        )
-        self.requires(
-            f"openexr/{os.environ['ASWF_OPENEXR_VERSION']}@{self.user}/{self.channel}"
-        )
+        self.requires(f"python/(latest)@{self.user}/{self.channel}")
+        self.requires(f"boost/(latest)@{self.user}/{self.channel}")
+        self.requires(f"openexr/(latest)@{self.user}/{self.channel}")
 
     def build_requirements(self):
-        self.build_requires(
-            f"cmake/{os.environ['ASWF_CMAKE_VERSION']}@{self.user}/{self.channel}"
-        )
+        self.build_requires(f"cmake/(latest)@{self.user}/{self.channel}")
 
     def source(self):
         tools.get(f"https://github.com/alembic/alembic/archive/{self.version}.tar.gz")

--- a/packages/conan/recipes/boost/conanfile.py
+++ b/packages/conan/recipes/boost/conanfile.py
@@ -69,9 +69,7 @@ class BoostConan(ConanFile):
 
     def requirements(self):
         if self._with_component("python"):
-            self.requires(
-                f"python/{os.environ['ASWF_PYTHON_VERSION']}@{self.user}/{self.channel}"
-            )
+            self.requires(f"python/(latest)@{self.user}/{self.channel}")
 
     @property
     def _source_subfolder(self):

--- a/packages/conan/recipes/imath/conanfile.py
+++ b/packages/conan/recipes/imath/conanfile.py
@@ -31,19 +31,13 @@ class ImathConan(ConanFile):
     def requirements(self):
         if self._is_dummy():
             return
-        self.requires(
-            f"python/{os.environ['ASWF_PYTHON_VERSION']}@{self.user}/{self.channel}"
-        )
-        self.requires(
-            f"boost/{os.environ['ASWF_BOOST_VERSION']}@{self.user}/{self.channel}"
-        )
+        self.requires(f"python/(latest)@{self.user}/{self.channel}")
+        self.requires(f"boost/(latest)@{self.user}/{self.channel}")
 
     def build_requirements(self):
         if self._is_dummy():
             return
-        self.build_requires(
-            f"cmake/{os.environ['ASWF_CMAKE_VERSION']}@{self.user}/{self.channel}"
-        )
+        self.build_requires(f"cmake/(latest)@{self.user}/{self.channel}")
 
     def source(self):
         if self._is_dummy():

--- a/packages/conan/recipes/openexr/conanfile.py
+++ b/packages/conan/recipes/openexr/conanfile.py
@@ -25,21 +25,13 @@ class OpenEXRConan(ConanFile):
     _source_subfolder = "source_subfolder"
 
     def requirements(self):
-        self.requires(
-            f"python/{os.environ['ASWF_PYTHON_VERSION']}@{self.user}/{self.channel}"
-        )
-        self.requires(
-            f"boost/{os.environ['ASWF_BOOST_VERSION']}@{self.user}/{self.channel}"
-        )
+        self.requires(f"python/(latest)@{self.user}/{self.channel}")
+        self.requires(f"boost/(latest)@{self.user}/{self.channel}")
         if tools.Version(self.version) >= "3":
-            self.requires(
-                f"imath/{os.environ['ASWF_IMATH_VERSION']}@{self.user}/{self.channel}"
-            )
+            self.requires(f"imath/(latest)@{self.user}/{self.channel}")
 
     def build_requirements(self):
-        self.build_requires(
-            f"cmake/{os.environ['ASWF_CMAKE_VERSION']}@{self.user}/{self.channel}"
-        )
+        self.build_requires(f"cmake/(latest)@{self.user}/{self.channel}")
 
     def source(self):
         tools.get(

--- a/packages/conan/recipes/pybind11/conanfile.py
+++ b/packages/conan/recipes/pybind11/conanfile.py
@@ -29,9 +29,7 @@ class PyBind11Conan(ConanFile):
     _cmake = None
 
     def requirements(self):
-        self.requires(
-            f"python/{os.environ['ASWF_PYTHON_VERSION']}@{self.user}/{self.channel}"
-        )
+        self.requires(f"python/(latest)@{self.user}/{self.channel}")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/packages/conan/recipes/pyside/conanfile.py
+++ b/packages/conan/recipes/pyside/conanfile.py
@@ -25,14 +25,12 @@ class PySideConan(ConanFile):
     _source_subfolder = "source_subfolder"
 
     def requirements(self):
-        self.requires(
-            f"python/{os.environ['ASWF_PYTHON_VERSION']}@{self.user}/{self.channel}"
-        )
-        self.requires(f"qt/{os.environ['ASWF_QT_VERSION']}@{self.user}/{self.channel}")
+        self.requires(f"python/(latest)@{self.user}/{self.channel}")
+        self.requires(f"qt/(latest)@{self.user}/{self.channel}")
 
     def build_requirements(self):
         self.build_requires(
-            f"clang/{os.environ['ASWF_CLANG_VERSION']}@{self.user}/ci_common{self.settings.ci_common}"
+            f"clang/(latest)@{self.user}/ci_common{self.settings.ci_common}"
         )
 
     def source(self):

--- a/packages/conan/recipes/python/conanfile.py
+++ b/packages/conan/recipes/python/conanfile.py
@@ -1,4 +1,3 @@
-from platform import python_version
 from conans import AutoToolsBuildEnvironment, ConanFile, tools
 from contextlib import contextmanager
 import os
@@ -20,8 +19,8 @@ class PythonConan(ConanFile):
         "vfx_platform",
         "python",
     )
-    options = {}
-    default_options = {}
+    options = {"with_numpy": [True, False]}
+    default_options = {"with_numpy": "ASWF_NUMPY_VERSION" in os.environ}
     generators = "pkg_config"
 
     _autotools = None
@@ -127,9 +126,11 @@ class PythonConan(ConanFile):
             }
         ):
             self.run(f"{py_exe} get-pip.py")
-            self.run(
-                f"{py_exe} -m pip install nose coverage docutils epydoc numpy=={os.environ['ASWF_NUMPY_VERSION']}"
-            )
+            self.run(f"{py_exe} -m pip install nose coverage docutils epydoc")
+            if self.options.get_safe("with_numpy"):
+                self.run(
+                    f"{py_exe} -m pip install numpy=={os.environ['ASWF_NUMPY_VERSION']}"
+                )
 
     def package_info(self):
         self.cpp_info.filenames["pkg_config"] = "python"

--- a/packages/conan/settings/remotes.json
+++ b/packages/conan/settings/remotes.json
@@ -1,18 +1,23 @@
 {
  "remotes": [
-  {
-   "name": "aswftesting-ab",
-   "url": "https://aloysbaillet.jfrog.io/artifactory/api/conan/aswftesting-conan",
-   "verify_ssl": true
-  },
-  {
-    "name": "aswf",
-    "url": "https://linuxfoundation.jfrog.io/artifactory/api/conan/aswf-conan",
-    "verify_ssl": true
-   },
    {
-     "name": "aswftesting",
-     "url": "https://linuxfoundation.jfrog.io/artifactory/api/conan/aswf-conan-dev",
+     "name": "aswf",
+     "url": "https://linuxfoundation.jfrog.io/artifactory/api/conan/aswf-conan",
+     "verify_ssl": true
+    },
+    {
+      "name": "conan-central",
+      "url": "https://center.conan.io",
+      "verify_ssl": true
+    },
+    {
+      "name": "aswftesting",
+      "url": "https://linuxfoundation.jfrog.io/artifactory/api/conan/aswf-conan-dev",
+      "verify_ssl": true
+    },
+    {
+     "name": "aswftesting-ab",
+     "url": "https://aloysbaillet.jfrog.io/artifactory/api/conan/aswftesting-conan",
      "verify_ssl": true
     }
   ]

--- a/packages/conan/settings/settings.yml
+++ b/packages/conan/settings/settings.yml
@@ -130,6 +130,8 @@ compiler:
                 exceptions: [None]
 
 build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
+
+# ASWF-specific settings"
 python: [None, "2.7", "3.7", "3.9"]
 devtoolset: [None, "6", "9"]
 ci_common: [None, "1", "2"]

--- a/python/aswfdocker/builder.py
+++ b/python/aswfdocker/builder.py
@@ -262,3 +262,17 @@ class Builder:
                     ],
                     dry_run,
                 )
+                alias_version = (
+                    f"{image}/latest"
+                    f"@{self.build_info.docker_org}/{version_info.conan_profile}"
+                )
+                self._run_in_docker(
+                    base_cmd,
+                    [
+                        "conan",
+                        "alias",
+                        alias_version,
+                        conan_version,
+                    ],
+                    dry_run,
+                )

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,6 @@ sonar.sources=.
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.pylint.reportPath=test-pylint-results.xml
 sonar.python.xunit.reportPath=test-pytest-results.xml
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-


### PR DESCRIPTION
The main advantage of using the conan aliases is that there is no need anymore to use ASWF_ env vars when requesting upstream dependencies in conan recipes, the alias will select the latest available version for a given year automatically!

Also some added docs, sonar cleanup, and added conan option to add numpy.