### PR TITLE
Switch to fast paid runner for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-16c-64g-600h
     env:
       DOCKER_CLI_EXPERIMENTAL: enabled
       DOCKER_BUILDKIT: '1'


### PR DESCRIPTION
We now have access to faster bigger machines for building, now using it.
This means I can now finally build Qt conan package!