### PR TITLE
Updated Dockerfile for ci-opencue

### DIFF
--- a/ci-opencue/Dockerfile
+++ b/ci-opencue/Dockerfile
@@ -82,11 +82,11 @@ ENV ASWF_PYTHON_MAJOR_MINOR_VERSION=$ASWF_PYTHON_MAJOR_MINOR_VERSION
 COPY ci-opencue/README.md ci-opencue/image.yaml /usr/local/aswf/
 
 RUN sudo yum -y install \
-    java-11-openjdk.x86_64 \
-    java-11-openjdk-devel.x86_64
-RUN sudo alternatives --set java java-11-openjdk.x86_64 && \
-    sudo alternatives --set javac java-11-openjdk.x86_64 && \
-    sudo alternatives --set jre_openjdk java-11-openjdk.x86_64
+    java-17-openjdk.x86_64 \
+    java-17-openjdk-devel.x86_64
+RUN sudo alternatives --set java java-17-openjdk.x86_64 && \
+    sudo alternatives --set javac java-17-openjdk.x86_64 && \
+    sudo alternatives --set jre_openjdk java-17-openjdk.x86_64
 
 
 ENV PYTHONPATH=/usr/local/lib/python${ASWF_PYTHON_MAJOR_MINOR_VERSION}/site-packages:/usr/local/lib64/python${ASWF_PYTHON_MAJOR_MINOR_VERSION}/site-packages:/usr/local/lib/python:${PYTHONPATH}


### PR DESCRIPTION
Follow up to PR #223: run `aswfdocker dockergen` to update ci-opencue
