### PR TITLE
Map settings into Conan 2 .conan2

### DIFF
--- a/.github/workflows/python-sonar.yml
+++ b/.github/workflows/python-sonar.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: 3.9
         cache: 'pipenv'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: 3.9
         cache: 'pipenv'

--- a/python/aswfdocker/builder.py
+++ b/python/aswfdocker/builder.py
@@ -197,7 +197,7 @@ class Builder:
         conan_base = os.path.join(utils.get_git_top_level(), "packages", "conan")
         vols = {
             os.path.join(conan_base, "settings"): os.path.join(
-                constants.CONAN_USER_HOME, ".conan"
+                constants.CONAN_USER_HOME, ".conan2"
             ),
             os.path.join(conan_base, "data"): os.path.join(
                 constants.CONAN_USER_HOME, "d"

--- a/scripts/common/install_opengl.sh
+++ b/scripts/common/install_opengl.sh
@@ -55,10 +55,7 @@ cd /tmp/gldev/EGL-Registry
 git checkout 0fa0d37da846998aa838ed2b784a340c28dadff3
 cp -r api/EGL api/KHR /usr/local/include
 cd /tmp/gldev
-#gitlab.freedesktop.org is down
-#git clone --branch=mesa-17.3.3 --depth=1 https://gitlab.freedesktop.org/mesa/mesa.git
-git clone --branch=mesa-17.3.3 --depth=1 https://github.com/chaotic-cx/mesa-mirror.git
-mv /tmp/gldev/mesa-mirror /tmp/gldev/mesa
+git clone --branch=mesa-17.3.3 --depth=1 https://gitlab.freedesktop.org/mesa/mesa.git
 cd /tmp/gldev/mesa
 mkdir -p /usr/local/include/GL
 cp include/GL/gl.h include/GL/gl_mangle.h /usr/local/include/GL/


### PR DESCRIPTION
In Conan 2 the CONAN_HOME is .conan2 not .conan, this should hopefully allow authenticating against remotes.

Also:

- pin GitHub Actions in 2 remaining workflows
- revert back to gitlab.freedesktop.org for Mesa3D