### PR TITLE
Use Docker BuildKit secrets for Conan authentication

### DIFF
--- a/packages/common/Dockerfile
+++ b/packages/common/Dockerfile
@@ -162,12 +162,6 @@ ENV GCC_INSTALL_PREFIX=/opt/rh/${ASWF_DTS_PREFIX}-${ASWF_DTS_VERSION}/root/usr
 # With "conan create --profile" we no longer need to set a default profile
 ENV CONAN_HOME=${CONAN_USER_HOME}/.conan2
 
-# Allow "conan upload" to authenticate without persistent storage
-ARG CONAN_LOGIN_USERNAME
-ENV CONAN_LOGIN_USERNAME=${CONAN_LOGIN_USERNAME}
-ARG CONAN_PASSWORD
-ENV CONAN_PASSWORD=${CONAN_PASSWORD}
-
 RUN --mount=type=cache,target=${CONAN_USER_HOME}/d \
     --mount=type=cache,target=${CCACHE_DIR} \
     --mount=type=bind,rw,target=${CONAN_USER_HOME}/.conan2,source=packages/conan/settings \
@@ -188,6 +182,8 @@ RUN --mount=type=cache,target=${CONAN_USER_HOME}/d \
     --mount=type=cache,target=${CCACHE_DIR} \
     --mount=type=bind,rw,target=${CONAN_USER_HOME}/.conan2,source=packages/conan/settings \
     --mount=type=bind,rw,target=${CONAN_USER_HOME}/recipes,source=packages/conan/recipes \
+    --mount=type=secret,id=conan_login_username,env=CONAN_LOGIN_USERNAME \
+    --mount=type=secret,id=conan_password,env=CONAN_PASSWORD \
     if [ -n "${ASWF_CONAN_PUSH}" ] ; then \
       conan upload --remote ${ASWF_PKG_ORG} ${ASWF_PKG_NAME}/${ASWF_PKG_VERSION}@${ASWF_PKG_ORG}/${ASWF_CONAN_CHANNEL} ;\
     else \

--- a/python/aswfdocker/tests/test_builder.py
+++ b/python/aswfdocker/tests/test_builder.py
@@ -194,6 +194,10 @@ class TestBuilder(unittest.TestCase):
                             f"{constants.DOCKER_REGISTRY}/aswflocaltesting/ci-openvdb:{openvdb_version}",
                         ],
                         "output": ["type=docker"],
+                        "secrets": [
+                            "id=conan_login_username,env=CONAN_LOGIN_USERNAME",
+                            "id=conan_password,env=CONAN_PASSWORD",
+                        ],
                     }
                 },
             },
@@ -281,6 +285,10 @@ class TestBuilder(unittest.TestCase):
                             f"{constants.DOCKER_REGISTRY}/aswflocaltesting/ci-base:{base_versions[1]}",
                         ],
                         "output": ["type=docker"],
+                        "secrets": [
+                            "id=conan_login_username,env=CONAN_LOGIN_USERNAME",
+                            "id=conan_password,env=CONAN_PASSWORD",
+                        ],
                     },
                     "ci-base-2019": {
                         "context": ".",
@@ -346,6 +354,10 @@ class TestBuilder(unittest.TestCase):
                             f"{constants.DOCKER_REGISTRY}/aswflocaltesting/ci-base:{base_versions[0]}",
                         ],
                         "output": ["type=docker"],
+                        "secrets": [
+                            "id=conan_login_username,env=CONAN_LOGIN_USERNAME",
+                            "id=conan_password,env=CONAN_PASSWORD",
+                        ],
                     },
                 },
             },
@@ -503,17 +515,15 @@ class TestBuilderCli(unittest.TestCase):
             tempfile.gettempdir(), "docker-bake-PACKAGE-vfx1-2-2019-2020.json"
         )
         cmds = result.output.strip().splitlines()
-        # We expect 5 steps
+        # We expect 3 steps
         # 1 - docker buildx to build the non-Conan packages
-        # 2 - docker run to login to repository (2x for each image)
-        # 3 - docker buildx to build and upload (2x for each openexr package)
-        self.assertEqual(len(cmds), 5)
+        # 2 - docker buildx to build and upload (2x for each openexr package)
+        self.assertEqual(len(cmds), 3)
         self.assertEqual(
             cmds[self._i],
             f"INFO:aswfdocker.builder:Would run: 'docker buildx bake -f {bake_path} --progress auto'",
         )
         self._i += 1
-        self._assertEndsWith(cmds, "conan remote auth aswftesting'")
         self.assertEqual(
             cmds[self._i],
             f"INFO:aswfdocker.builder:Would run: 'docker buildx bake -f {bake_path} "
@@ -521,7 +531,6 @@ class TestBuilderCli(unittest.TestCase):
             + "--progress auto ci-package-openexr-2019'",
         )
         self._i += 1
-        self._assertEndsWith(cmds, "conan remote auth aswftesting'")
         self.assertEqual(
             cmds[self._i],
             f"INFO:aswfdocker.builder:Would run: 'docker buildx bake -f {bake_path} "


### PR DESCRIPTION
We don't have a simple way to persist Conan authentication against a remote repository, instead use the BuildKit secrets mechanism to pass CONAN_LOGIN_USERNAME and CONAN_PASSWORD secrets env vars to the build container.