### PR TITLE
Mounting buildx secrets into env var requires Dockerfile 1.10

### DIFF
--- a/ci-base/Dockerfile
+++ b/ci-base/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-baseqt/Dockerfile
+++ b/ci-baseqt/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-common/Dockerfile
+++ b/ci-common/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-materialx/Dockerfile
+++ b/ci-materialx/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-ocio/Dockerfile
+++ b/ci-ocio/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-oiio/Dockerfile
+++ b/ci-oiio/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-opencue/Dockerfile
+++ b/ci-opencue/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-openexr/Dockerfile
+++ b/ci-openexr/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-openrv/Dockerfile
+++ b/ci-openrv/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-openvdb/Dockerfile
+++ b/ci-openvdb/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-osl/Dockerfile
+++ b/ci-osl/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-otio/Dockerfile
+++ b/ci-otio/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-usd/Dockerfile
+++ b/ci-usd/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci-vfxall/Dockerfile
+++ b/ci-vfxall/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/common/Dockerfile
+++ b/packages/common/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/python/aswfdocker/builder.py
+++ b/python/aswfdocker/builder.py
@@ -131,7 +131,7 @@ class Builder:
                 },
                 "tags": tags,
                 "output": ["type=registry,push=true" if self.push else "type=docker"],
-                "secrets": [
+                "secret": [
                     "id=conan_login_username,env=CONAN_LOGIN_USERNAME",
                     "id=conan_password,env=CONAN_PASSWORD",
                 ],
@@ -235,7 +235,6 @@ class Builder:
         version,
         dry_run,
         progress,
-        conan_login,
         bake_jsonfile,
     ):
         # pylint: disable=consider-using-f-string
@@ -246,7 +245,7 @@ class Builder:
         #     # "conan remote auth" stores credentials in
         #     # ${CONAN_HOME]/.conan2/credentials.json but we don't have a simple way to persist
         #     # this file between build steps, since instead we will use the secrets mechanism
-        #     # in the buildx bake file to pass the CONNA_LOGIN_USERNAME and CONAN_PASSWORD
+        #     # in the buildx bake file to pass the CONAN_LOGIN_USERNAME and CONAN_PASSWORD
         #     # values as environment variables to allow `conan upload" to authenticate on the fly.
         #     self._run_in_docker(
         #        base_cmd,
@@ -307,7 +306,6 @@ class Builder:
         progress: str = "",
         keep_source=False,
         keep_build=False,
-        conan_login=False,
         build_missing=False,
     ) -> None:
         images_and_versions = []
@@ -343,6 +341,5 @@ class Builder:
                 version,
                 dry_run,
                 progress,
-                conan_login,
                 path,
             )

--- a/python/aswfdocker/cli/aswfdocker.py
+++ b/python/aswfdocker/cli/aswfdocker.py
@@ -168,7 +168,7 @@ def get_group_info(build_info, ci_image_type, groups, versions, full_name, targe
     "--conan-login",
     "-cl",
     is_flag=True,
-    help="Instruct build to perform a `conan user -p` to login.",
+    help="[DEPRECATED] This option is no longer used as authentication is now handled via buildx secrets.",
 )
 @click.option(
     "--build-missing",
@@ -212,7 +212,6 @@ def build(
         progress=progress,
         keep_source=keep_source,
         keep_build=keep_build,
-        conan_login=conan_login,
         build_missing=build_missing,
     )
 

--- a/python/aswfdocker/data/ci-image-dockerfile.jinja2
+++ b/python/aswfdocker/data/ci-image-dockerfile.jinja2
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.10
 # Copyright (c) Contributors to the aswf-docker Project. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/python/aswfdocker/tests/test_builder.py
+++ b/python/aswfdocker/tests/test_builder.py
@@ -194,7 +194,7 @@ class TestBuilder(unittest.TestCase):
                             f"{constants.DOCKER_REGISTRY}/aswflocaltesting/ci-openvdb:{openvdb_version}",
                         ],
                         "output": ["type=docker"],
-                        "secrets": [
+                        "secret": [
                             "id=conan_login_username,env=CONAN_LOGIN_USERNAME",
                             "id=conan_password,env=CONAN_PASSWORD",
                         ],
@@ -285,7 +285,7 @@ class TestBuilder(unittest.TestCase):
                             f"{constants.DOCKER_REGISTRY}/aswflocaltesting/ci-base:{base_versions[1]}",
                         ],
                         "output": ["type=docker"],
-                        "secrets": [
+                        "secret": [
                             "id=conan_login_username,env=CONAN_LOGIN_USERNAME",
                             "id=conan_password,env=CONAN_PASSWORD",
                         ],
@@ -354,7 +354,7 @@ class TestBuilder(unittest.TestCase):
                             f"{constants.DOCKER_REGISTRY}/aswflocaltesting/ci-base:{base_versions[0]}",
                         ],
                         "output": ["type=docker"],
-                        "secrets": [
+                        "secret": [
                             "id=conan_login_username,env=CONAN_LOGIN_USERNAME",
                             "id=conan_password,env=CONAN_PASSWORD",
                         ],


### PR DESCRIPTION
Mounting buildx secrets into environment variables requires Dockerfile syntax 1.10 or newer.

Mark conan-login CLI parameter to aswfdocker as obsolete.