### PR TITLE
Redirect Conan - Artifactory authentication variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: enabled
       DOCKER_BUILDKIT: '1'
-      ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
-      ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+      CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USER }}
+      CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_TOKEN }}
 
     strategy:
       matrix:

--- a/python/aswfdocker/cli/aswfdocker.py
+++ b/python/aswfdocker/cli/aswfdocker.py
@@ -190,7 +190,7 @@ def build(
     use_conan,
     keep_source,
     keep_build,
-    conan_login,
+    conan_login,  # pylint: disable=unused-argument
     build_missing,
 ):
     """Builds a ci-package or ci-image Docker image."""


### PR DESCRIPTION
The secrets for authentication against the Artifactory repository are called ARTIFACTORY_USER and ARTIFACTORY_TOKEN, copy those to environment variables CONAN_LOGIN_USERNAME and CONAN_PASSWORD which are expected by Conan to authenticate package uploads.

Also fix pylint warning for obsolete --conan-login option to aswfdocker CLI which was breaking Sonar scan.