### PR TITLE
Second attempt at workaround for empty GITHUB_REF variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       DOCKER_BUILDKIT: '1'
       CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USER }}
       CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_TOKEN }}
-      GITHUB_REF_LOCAL: ${{ github.ref }}
+      GITHUB_REF_LOCAL: ${{ github.ref || format('{0}{1}', 'refs/tags/', github.event.release.tag_name) }}
 
     strategy:
       matrix:


### PR DESCRIPTION
If `${{ github.ref }}` is empty then use `${{ github.event.release.tag_name }}` to build ref.