### PR TITLE
b2 is a tool_requires

### DIFF
--- a/packages/conan/settings/profiles_aswf/vfx2024
+++ b/packages/conan/settings/profiles_aswf/vfx2024
@@ -5,8 +5,8 @@ include(ci_common4)
 # Build everything as shared libs by default
 *:shared=True
 [tool_requires]
-[replace_requires]
 b2/*: b2/5.2.1@aswf/vfx2024
+[replace_requires]
 boost/*: boost/1.82.0@aswf/vfx2024
 brotli/*: brotli/system@aswf/vfx2024
 bzip2/*: bzip2/1.0.8@aswf/vfx2024

--- a/packages/conan/settings/profiles_aswf/vfx2025
+++ b/packages/conan/settings/profiles_aswf/vfx2025
@@ -5,8 +5,8 @@ include(ci_common5)
 # Build everything as shared libs by default
 *:shared=True
 [tool_requires]
-[replace_requires]
 b2/*: b2/5.2.1@aswf/vfx2025
+[replace_requires]
 boost/*: boost/1.85.0@aswf/vfx2025
 brotli/*: brotli/system@aswf/vfx2025
 bzip2/*: bzip2/1.0.8@aswf/vfx2025

--- a/packages/conan/settings/profiles_aswftesting/vfx2024
+++ b/packages/conan/settings/profiles_aswftesting/vfx2024
@@ -5,8 +5,8 @@ include(ci_common4)
 # Build everything as shared libs by default
 *:shared=True
 [tool_requires]
-[replace_requires]
 b2/*: b2/5.2.1@aswftesting/vfx2024
+[replace_requires]
 boost/*: boost/1.82.0@aswftesting/vfx2024
 brotli/*: brotli/system@aswftesting/vfx2024
 bzip2/*: bzip2/1.0.8@aswftesting/vfx2024

--- a/packages/conan/settings/profiles_aswftesting/vfx2025
+++ b/packages/conan/settings/profiles_aswftesting/vfx2025
@@ -5,8 +5,8 @@ include(ci_common5)
 # Build everything as shared libs by default
 *:shared=True
 [tool_requires]
-[replace_requires]
 b2/*: b2/5.2.1@aswftesting/vfx2025
+[replace_requires]
 boost/*: boost/1.85.0@aswftesting/vfx2025
 brotli/*: brotli/system@aswftesting/vfx2025
 bzip2/*: bzip2/1.0.8@aswftesting/vfx2025


### PR DESCRIPTION
Override of b2 version belongs in tool_requires section, otherwise we pick up Conan Central binary package which is compiled against newer libstdc++ version than we have in EL 8.