### PR TITLE
Fix OneTBB Conan version for 2025, rawtoaces 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ consumers of these new images.
     - OIIO 2.5.19.0 (was 2.5.16.0)
     - OpenFX 1.5s (new)
     - PySide 6.5.6 (was 6.5.4)
-    - rawtoaces 1.1-rc3 (new)
+    - rawtoaces 1.1.0 (new)
 - 2025.2 release
   - updated versions
     - Conan 2.18.1 (was 2.14.0)
@@ -56,7 +56,7 @@ consumers of these new images.
     - OSL 1.14.7.0 (was 1.14.5.1)
     - PySide 6.5.6 (was 6.5.4)
     - USD 25.05.01 (was 25.05)
-    - rawtoaces 1.1-rc3 (new)
+    - rawtoaces 1.1.0 (new)
 - 2026.0 draft images
   - pre-release for testing purposes, does not yet include final versions of late releasing packages for VFX Platform 2026 (OOCIO, OpenEXR, OpenVDB, OpenSubDiv)
   - OpenEXR includes a pre-release of 3.4.x

--- a/ci-rawtoaces/README.md
+++ b/ci-rawtoaces/README.md
@@ -21,21 +21,21 @@ Warning: this image does *not* contain rawtoaces itself as it is used to *build*
 ## [aswf/ci-rawtoaces:2024.3](https://hub.docker.com/r/aswf/ci-rawtoaces/tags?page=1&name=2024.3)
 
 Contains:
-* rawtoaces-1.1-rc3
+* rawtoaces-1.1.0
 * numpy-1.24.3
 * vfxplatform-2024
 
 ## [aswf/ci-rawtoaces:2025.2](https://hub.docker.com/r/aswf/ci-rawtoaces/tags?page=1&name=2025.2)
 
 Contains:
-* rawtoaces-1.1-rc3
+* rawtoaces-1.1.0
 * numpy-1.26.4
 * vfxplatform-2025
 
 ## [aswf/ci-rawtoaces:2026.0](https://hub.docker.com/r/aswf/ci-rawtoaces/tags?page=1&name=2026.0)
 
 Contains:
-* rawtoaces-1.1-rc3
+* rawtoaces-1.1.0
 * numpy-2.3.2
 * vfxplatform-2026
 

--- a/ci-vfxall/README.md
+++ b/ci-vfxall/README.md
@@ -346,7 +346,7 @@ Contains:
 * usd-24.08
 * osl-1.13.11.0
 * otio-0.17.0
-* rawtoaces-1.1-rc3
+* rawtoaces-1.1.0
 * numpy-1.24.3
 * vfxplatform-2024
 
@@ -373,7 +373,7 @@ Contains:
 * usd-24.08
 * osl-1.13.11.0
 * otio-0.17.0
-* rawtoaces-1.1-rc3
+* rawtoaces-1.1.0
 * numpy-1.24.3
 * vfxplatform-2024
 
@@ -400,7 +400,7 @@ Contains:
 * usd-25.05.01
 * osl-1.14.7.0
 * otio-0.17.0
-* rawtoaces-1.1-rc3
+* rawtoaces-1.1.0
 * numpy-1.26.4
 * vfxplatform-2025
 
@@ -427,7 +427,7 @@ Contains:
 * usd-25.05.01
 * osl-1.14.7.0
 * otio-0.17.0
-* rawtoaces-1.1-rc3
+* rawtoaces-1.1.0
 * numpy-1.26.4
 * vfxplatform-2025
 
@@ -454,7 +454,7 @@ Contains:
 * usd-25.08
 * osl-1.14.7.0
 * otio-0.17.0
-* rawtoaces-1.1-rc3
+* rawtoaces-1.1.0
 * numpy-2.3.2
 * vfxplatform-2026
 
@@ -481,7 +481,7 @@ Contains:
 * usd-25.08
 * osl-1.14.7.0
 * otio-0.17.0
-* rawtoaces-1.1-rc3
+* rawtoaces-1.1.0
 * numpy-2.3.2
 * vfxplatform-2026
 

--- a/packages/conan/recipes/rawtoaces/conandata.yml
+++ b/packages/conan/recipes/rawtoaces/conandata.yml
@@ -4,6 +4,9 @@
 #
 
 sources:
+  "1.1.0":
+    url: "https://github.com/AcademySoftwareFoundation/rawtoaces/archive/refs/tags/v1.1.tar.gz"
+    sha256: "3c919d9d47c2faa4ff989f4698d44196b8857374ffebd9dd5bf59e2676075329"
   "1.1-rc3":
     url: "https://github.com/AcademySoftwareFoundation/rawtoaces/archive/refs/tags/v1.1-RC3.tar.gz"
     sha256: "773451aa3cd05bcf91af7ff4150678e2230f1f5c495fd93030cde8c77e6c0c07"
@@ -11,6 +14,11 @@ sources:
     url: "https://github.com/AcademySoftwareFoundation/rawtoaces/archive/refs/tags/vfx2026.0.tar.gz"
     sha256: "292fdf087dd5543f2de08fb85378f62489436a3146c657b80a0f52ca227680c7"
 patches:
+  "1.1.0":
+    - patch_file: "patches/1.1-rc3-cmake_libraw_target.diff"
+      patch_description: "libraw Cmake target from Conan Center Index recipe"
+      patch_type: "conan"
+
   "1.1-rc3":
     - patch_file: "patches/1.1-rc3-cmake_libraw_target.diff"
       patch_description: "libraw Cmake target from Conan Center Index recipe"

--- a/packages/conan/settings/profiles_aswf/vfx2024
+++ b/packages/conan/settings/profiles_aswf/vfx2024
@@ -67,7 +67,7 @@ nss/*: nss/3.101.0@aswf/vfx2024
 ocio/*: ocio/2.3.2@aswf/vfx2024
 ogg/*: ogg/system@aswf/vfx2024
 oiio/*: oiio/2.5.19.0@aswf/vfx2024
-onetbb/*: onetbb/2020_u3@aswftesting/vfx2024
+onetbb/*: onetbb/2020_u3@aswf/vfx2024
 openal-soft/*: openal-soft/system@aswf/vfx2024
 opencl-headers/*: opencl-headers/system@aswf/vfx2024
 opencl-icd-loader/*: opencl-icd-loader/system@aswf/vfx2024

--- a/python/aswfdocker/data/versions.yaml
+++ b/python/aswfdocker/data/versions.yaml
@@ -630,7 +630,7 @@ versions:
       ASWF_OPENVDB_VERSION: "11.0.0"
       ASWF_OSL_VERSION: "1.13.11.0"
       ASWF_OTIO_VERSION: "0.17.0"
-      ASWF_RAWTOACES_VERSION: "1.1-rc3"
+      ASWF_RAWTOACES_VERSION: "1.1.0"
   "2024-clang16":
     parent_versions: ["4", "4-clang16", "2024"]
     major_version: "2024"
@@ -765,7 +765,7 @@ versions:
       ASWF_OPENVDB_VERSION: "12.0.1"
       ASWF_OSL_VERSION: "1.14.7.0"
       ASWF_OTIO_VERSION: "0.17.0"
-      ASWF_RAWTOACES_VERSION: "1.1-rc3" 
+      ASWF_RAWTOACES_VERSION: "1.1.0" 
   "2025-clang18":
     parent_versions: ["5", "5-clang18", "2025"]
     major_version: "2025"
@@ -901,7 +901,7 @@ versions:
       ASWF_OPENVDB_VERSION: "12.0.1"
       ASWF_OSL_VERSION: "1.14.7.0"
       ASWF_OTIO_VERSION: "0.17.0"
-      ASWF_RAWTOACES_VERSION: "1.1-rc3"
+      ASWF_RAWTOACES_VERSION: "1.1.0"
   "2026-clang19":
     parent_versions: ["6", "6-clang19", "2026"]
     major_version: "2026"


### PR DESCRIPTION
rawtoaces 1.1.0 is identical to 1.1-RC3 but version is cleaner.