### PR TITLE
Don't always rebuilt ci-baseos-gl-conan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
             build: true
             push_description: true
           - group: conan
-            args: --use-conan --conan-login --build-missing
+            args: --use-conan --conan-login
             build: ${{ contains(github.ref, '/ci-package') }}
             push_description: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-# 2025-09-01
+# 2025-09-03
 
 2024.4 / 2025.3 / 2026.1 releases to address issues in the previous set of releases encountered by consumer
 ASWF projects. This highlights the need for more thorough testing of non-Conan project builds in the
@@ -20,6 +20,8 @@ resulting ci-XXXX images.
   - Fix some discrepancies in the Conan 2 environment files (we really need a single
   source of truth for all version information).
   - Build command line utilities and Ax when building OpenVDB package, and install missing dependencies for these additional components (glfw3). Ax cannot be built with OpenVDB older than 12.1.0 since this is where support for clang/llvm 16 or newer shows up.
+  - Dockerfile to build ci-baseos-gl-conan image should how pull from Docker Hub instead of always rebuilding locally
+  - release.yml GHA workflow should now always rebuild even if an existing binary package exists in the Conan repository
 - 2024.4
   - revert to MaterialX 1.39.1 which is complatible with USD 24.08
   - install MaterialX CMake files in expected location

--- a/packages/common/Dockerfile
+++ b/packages/common/Dockerfile
@@ -21,7 +21,7 @@ ARG ASWF_BASEOS_IMAGE
 
 
 #################### ci-baseos-gl-os ####################
-FROM ${ASWF_BASEOS_IMAGE}:${ASWF_CUDA_VERSION}-runtime-${ASWF_BASEOS_DISTRO} AS ci-baseos-gl-os
+FROM ${ASWF_BASEOS_IMAGE}:${ASWF_CUDA_VERSION}-runtime-${ASWF_BASEOS_DISTRO} AS ci-baseos-gl-conan
 
 ARG CI_COMMON_VERSION
 ENV CI_COMMON_VERSION=${CI_COMMON_VERSION}
@@ -91,13 +91,13 @@ COPY scripts/common/install_yq.sh /tmp/
 
 RUN /tmp/install_yq.sh
 
-#################### ci-baseos-gl-conan ####################
-FROM ci-baseos-gl-os AS ci-baseos-gl-conan
+# Merge the previously separate ci-baseos-gl-os and ci-baseos-gl-conan stages:
+# we are unlikely to want to iterate on Conan versions separately from the base image,
+# and we want to make sure that ci-conan-package-builder always pulls a pre-built
+# ci-baseos-gl-conan from Docker Hub rather than rebuilding it locally.
 
 ARG ASWF_CONAN_VERSION
 ARG ASWF_CONAN_PYTHON_VERSION
-ARG ASWF_DTS_VERSION
-ARG ASWF_DTS_PREFIX
 
 ENV ASWF_CONAN_ROOT=/opt/conan
 

--- a/packages/conan/settings/profiles_aswf/ci_common4
+++ b/packages/conan/settings/profiles_aswf/ci_common4
@@ -14,6 +14,7 @@ clang/*:shared=False
 [replace_requires]
 [replace_tool_requires]
 cmake/*: cmake/3.31.7@aswf/ci_common4
+ninja/*: ninja/1.13.1@aswf/ci_common4
 [platform_requires]
 [buildenv]
 GCC_INSTALL_DIR=/opt/rh/gcc-toolset-11/root/lib/gcc/x86_64-redhat-linux/11

--- a/packages/conan/settings/profiles_aswf/ci_common5
+++ b/packages/conan/settings/profiles_aswf/ci_common5
@@ -14,6 +14,7 @@ clang/*:shared=False
 [replace_requires]
 [replace_tool_requires]
 cmake/*: cmake/3.31.7@aswf/ci_common5
+ninja/*: ninja/1.13.1@aswf/ci_common5
 [platform_requires]
 [buildenv]
 GCC_INSTALL_DIR=/opt/rh/gcc-toolset-11/root/lib/gcc/x86_64-redhat-linux/11

--- a/packages/conan/settings/profiles_aswf/ci_common6
+++ b/packages/conan/settings/profiles_aswf/ci_common6
@@ -14,6 +14,7 @@ clang/*:shared=False
 [replace_requires]
 [replace_tool_requires]
 cmake/*: cmake/4.0.2@aswf/ci_common6
+ninja/*: ninja/1.13.1@aswf/ci_common6
 [platform_requires]
 [buildenv]
 GCC_INSTALL_DIR=/opt/rh/gcc-toolset-14/root/lib/gcc/x86_64-redhat-linux/14

--- a/packages/conan/settings/profiles_aswf/vfx2024
+++ b/packages/conan/settings/profiles_aswf/vfx2024
@@ -109,7 +109,6 @@ gperf/*: gperf/3.1@system
 libtool/*: libtool/2.4.6@system
 mesno/*: meson/0.58.2@system
 nasm/*: nasm/system@aswf/vfx2024
-ninja/*: ninja/1.13.1@aswf/ci_common5
 nodejs/*: nodejs/18.20.4@system
 pkgconf/*: pkgconf/1.4.2@system
 wayland/*: wayland/1.21.0@system

--- a/packages/conan/settings/profiles_aswf/vfx2025
+++ b/packages/conan/settings/profiles_aswf/vfx2025
@@ -109,7 +109,6 @@ gperf/*: gperf/3.1@system
 libtool/*: libtool/2.4.6@system
 meson/*: meson/0.58.2@system
 nasm/*: nasm/system@aswf/vfx2025
-ninja/*: ninja/1.13.1@aswf/ci_common5
 nodejs/*: nodejs/18.20.4@system
 pkgconf/*: pkgconf/1.4.2@system
 wayland/*: wayland/1.21.0@system

--- a/packages/conan/settings/profiles_aswf/vfx2026
+++ b/packages/conan/settings/profiles_aswf/vfx2026
@@ -111,7 +111,6 @@ gperf/*: gperf/3.1@system
 libtool/*: libtool/2.4.6@system
 meson/*: meson/0.58.2@system
 nasm/*: nasm/system@aswf/vfx2026
-ninja/*: ninja/1.13.1@aswf/ci_common6
 nodejs/*: nodejs/18.20.4@system
 pkgconf/*: pkgconf/1.4.2@system
 wayland/*: wayland/1.21.0@system

--- a/packages/conan/settings/profiles_aswftesting/ci_common4
+++ b/packages/conan/settings/profiles_aswftesting/ci_common4
@@ -14,6 +14,7 @@ clang/*:shared=False
 [replace_requires]
 [replace_tool_requires]
 cmake/*: cmake/3.31.7@aswftesting/ci_common4
+ninja/*: ninja/1.13.1@aswftesting/ci_common4
 [platform_requires]
 [buildenv]
 GCC_INSTALL_DIR=/opt/rh/gcc-toolset-11/root/lib/gcc/x86_64-redhat-linux/11

--- a/packages/conan/settings/profiles_aswftesting/ci_common5
+++ b/packages/conan/settings/profiles_aswftesting/ci_common5
@@ -14,6 +14,7 @@ clang/*:shared=False
 [replace_requires]
 [replace_tool_requires]
 cmake/*: cmake/3.31.7@aswftesting/ci_common5
+ninja/*: ninja/1.13.1@aswftesting/ci_common5
 [platform_requires]
 [buildenv]
 GCC_INSTALL_DIR=/opt/rh/gcc-toolset-11/root/lib/gcc/x86_64-redhat-linux/11

--- a/packages/conan/settings/profiles_aswftesting/ci_common6
+++ b/packages/conan/settings/profiles_aswftesting/ci_common6
@@ -14,6 +14,7 @@ clang/*:shared=False
 [replace_requires]
 [replace_tool_requires]
 cmake/*: cmake/4.0.2@aswftesting/ci_common6
+ninja/*: ninja/1.13.1@aswftesting/ci_common6
 [platform_requires]
 [buildenv]
 GCC_INSTALL_DIR=/opt/rh/gcc-toolset-14/root/lib/gcc/x86_64-redhat-linux/14

--- a/packages/conan/settings/profiles_aswftesting/vfx2024
+++ b/packages/conan/settings/profiles_aswftesting/vfx2024
@@ -109,7 +109,6 @@ gperf/*: gperf/3.1@system
 libtool/*: libtool/2.4.6@system
 mesno/*: meson/0.58.2@system
 nasm/*: nasm/system@aswftesting/vfx2024
-ninja/*: ninja/1.13.1@aswftesting/ci_common5
 nodejs/*: nodejs/18.20.4@system
 pkgconf/*: pkgconf/1.4.2@system
 wayland/*: wayland/1.21.0@system

--- a/packages/conan/settings/profiles_aswftesting/vfx2025
+++ b/packages/conan/settings/profiles_aswftesting/vfx2025
@@ -109,7 +109,6 @@ gperf/*: gperf/3.1@system
 libtool/*: libtool/2.4.6@system
 meson/*: meson/0.58.2@system
 nasm/*: nasm/system@aswftesting/vfx2025
-ninja/*: ninja/1.13.1@aswftesting/ci_common5
 nodejs/*: nodejs/18.20.4@system
 pkgconf/*: pkgconf/1.4.2@system
 wayland/*: wayland/1.21.0@system

--- a/packages/conan/settings/profiles_aswftesting/vfx2026
+++ b/packages/conan/settings/profiles_aswftesting/vfx2026
@@ -111,7 +111,6 @@ gperf/*: gperf/3.1@system
 libtool/*: libtool/2.4.6@system
 meson/*: meson/0.58.2@system
 nasm/*: nasm/system@aswftesting/vfx2026
-ninja/*: ninja/1.13.1@aswftesting/ci_common6
 nodejs/*: nodejs/18.20.4@system
 pkgconf/*: pkgconf/1.4.2@system
 wayland/*: wayland/1.21.0@system


### PR DESCRIPTION
- ci-baseos-gl-conan is used to build all Conan packages, make sure it gets pull from Docker Hub instead of constantly rebuilding it (10 minutes per trivial Conan wrapper package...)
- force Conan packages to always rebuild in release.yml GHA workflow
- move ninja version override to correct place in ci_commonX and fix typo