### PR TITLE
Fix OIIO build against OpenJPH for 2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-# 2025-11-08
+# 2025-11-09
 
 2024.5 / 2025.4 / 2026.2 releases. VFX Platform 2026 release is now feature complete.
 
 - All releases
   - Add OpenJPH 0.24.5 package
-    - OIIO builds against OpenJPH to handle JPEG-2000 j2c files ([#312](https://github.com/AcademySoftwareFoundation/aswf-docker/issues/312))
+    - OIIO 3.x in 2025/2026 builds against OpenJPH to handle JPEG-2000 j2c files ([#312](https://github.com/AcademySoftwareFoundation/aswf-docker/issues/312))
   - Add build_XXX.sh in /usr/local and missing env vars to ci-XXX images to help test images ([307](https://github.com/AcademySoftwareFoundation/aswf-docker/issues/307))
   - Separate ci-imath image include Imath dependencies but not Imath itself ([306](https://github.com/AcademySoftwareFoundation/aswf-docker/issues/306))
 - 2024.4

--- a/packages/conan/recipes/oiio/patches/3.1.6.2-raw-jp2k-cmake.patch
+++ b/packages/conan/recipes/oiio/patches/3.1.6.2-raw-jp2k-cmake.patch
@@ -19,7 +19,7 @@ diff --git src/jpeg2000.imageio/CMakeLists.txt src/jpeg2000.imageio/CMakeLists.t
 index d99dd79ac..bfda2778a 100644
 --- src/jpeg2000.imageio/CMakeLists.txt
 +++ src/jpeg2000.imageio/CMakeLists.txt
-@@ -2,10 +2,10 @@
+@@ -2,13 +2,16 @@
  # SPDX-License-Identifier: Apache-2.0
  # https://github.com/AcademySoftwareFoundation/OpenImageIO
 
@@ -34,6 +34,12 @@ index d99dd79ac..bfda2778a 100644
      set(_jpeg2000_defs "USE_OPENJPEG")
 
      if (openjph_FOUND)
++        list(APPEND _jpeg2000_includes ${openjph_INCLUDE_DIR})
++        list(APPEND _jpeg2000_lib_dirs ${openjph_LIB_DIRS_RELEASE})
++        list(APPEND _jpeg2000_libs ${openjph_LIBS_RELEASE})
+         list(APPEND _jpeg2000_defs "USE_OPENJPH")
+     endif()
+
 diff --git src/cmake/modules/FindLibRaw.cmake src/cmake/FindLibRaw.cmake
 index d99dd79ac..bfda2778a 100644
 --- src/cmake/modules/FindLibRaw.cmake


### PR DESCRIPTION
src/jpeg2000.imageio/CMakeLists.txt assumes the includes for openjph are in the same location as openjpeg which is not the case when building in Conan.

This doesn't show up in 2026 since openexr 3.4.x declares a dependency on openjph and since OIIO has a dependency on openexr, it gets the include path that way.