### PR TITLE
No more sudo wrappers with gcc-toolset 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 Re-releasing 2025.5 / 2025.4 / 2026.2 without 1.5GB of Conan download cache bloat.
 
+Also 2026 images use gcc-toolset 14, which no longer has a sudo wrapper preserving PATH / LD_LIBRARY_PATH.
+Get rid of calls to sudo which try to run binaries in /usr/local/bin.
+
 # 2025-11-09
 
 2024.5 / 2025.4 / 2026.2 releases. VFX Platform 2026 release is now feature complete.

--- a/ci-otio/Dockerfile
+++ b/ci-otio/Dockerfile
@@ -270,4 +270,4 @@ RUN --mount=type=cache,target=/opt/conan_home/d \
     /tmp/install_conanpackages.sh /usr/local vfx${ASWF_VFXPLATFORM_VERSION} otio
 
 
-RUN sudo pip3 install flake8 tox urllib3
+RUN pip3 install flake8 tox urllib3

--- a/ci-otio/image.yaml
+++ b/ci-otio/image.yaml
@@ -44,4 +44,4 @@ implicit_packages:
 docker_from: ${ASWF_ORG}/ci-common:${CI_COMMON_VERSION}-clang${ASWF_CLANG_MAJOR_VERSION}
 docker_package_version: $ASWF_VFXPLATFORM_VERSION
 docker_post_commands: |
-  RUN sudo pip3 install flake8 tox urllib3
+  RUN pip3 install flake8 tox urllib3

--- a/ci-usd/Dockerfile
+++ b/ci-usd/Dockerfile
@@ -337,4 +337,4 @@ RUN --mount=type=cache,target=/opt/conan_home/d \
     /tmp/install_conanpackages.sh /usr/local vfx${ASWF_VFXPLATFORM_VERSION} usd
 
 
-RUN sudo pip3 install jinja2 PyOpenGL
+RUN pip3 install jinja2 PyOpenGL

--- a/ci-usd/image.yaml
+++ b/ci-usd/image.yaml
@@ -57,4 +57,4 @@ implicit_packages:
 docker_from: ${ASWF_ORG}/ci-common:${CI_COMMON_VERSION}-clang${ASWF_CLANG_MAJOR_VERSION}
 docker_package_version: $ASWF_VFXPLATFORM_VERSION
 docker_post_commands: |
-  RUN sudo pip3 install jinja2 PyOpenGL
+  RUN pip3 install jinja2 PyOpenGL


### PR DESCRIPTION
Don't spuriously call sudo for binaries in /usr/local/bin, sudo won't have that in its PATH or LD_LIBRARY_PATH.