### PR TITLE
Fix SonarCloud scanning

### DIFF
--- a/.github/workflows/python-sonar.yml
+++ b/.github/workflows/python-sonar.yml
@@ -32,9 +32,6 @@ jobs:
     - name: Run pylint linter
       run: pipenv run pytest python/aswfdocker --doctest-modules --pylint --junitxml=test-pylint-results.xml --cov=. --cov-report=xml
 
-    - name: Fetch unshallow to help sonar
-      run: git fetch --unshallow
-
     - name: Install and Run Sonar Scanner
       uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
   - Update GitHub action versions for [NodeJS 24](https://github.com/AcademySoftwareFoundation/aswf-docker/issues/350)
   - Update some Python dependencies
   - [Enable building iv for OpenImageIO](https://github.com/AcademySoftwareFoundation/aswf-docker/issues/357) to include Qt in ci-oiio, re-release ci-oiio 2026.3 / 2025.5 / 2024.6 images
+  - Update and fix [SonarCloud scanning](https://github.com/AcademySoftwareFoundation/aswf-docker/issues/331), excluding vendored Conan recipes from analysis
 
 # 2026-02-24
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -351,12 +351,12 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
-                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
+                "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+                "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.4"
+            "version": "==3.1.6"
         },
         "librt": {
             "hashes": [
@@ -1532,12 +1532,12 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
-                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
+                "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+                "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.4"
+            "version": "==3.1.6"
         },
         "keyring": {
             "hashes": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,7 @@
 sonar.organization=academysoftwarefoundation
 sonar.projectKey=AcademySoftwareFoundation_aswf-docker
 sonar.sources=.
+sonar.exclusions=packages/conan/recipes
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.pylint.reportPath=test-pylint-results.xml
 sonar.python.xunit.reportPath=test-pytest-results.xml


### PR DESCRIPTION
- checkout depth already specified by actions/checkout
- exclude from Sonar analysis vendored Conan recipes which we don't want to change
- update jinja2 Python module