### PR TITLE
Fix SonarCloud Conan recipe exclusions

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -738,12 +738,12 @@
         },
         "requests": {
             "hashes": [
-                "sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5",
-                "sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8"
+                "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+                "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==2.32.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.32.5"
         },
         "setuptools": {
             "hashes": [
@@ -2133,12 +2133,12 @@
         },
         "requests": {
             "hashes": [
-                "sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5",
-                "sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8"
+                "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+                "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==2.32.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.32.5"
         },
         "requests-toolbelt": {
             "hashes": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=academysoftwarefoundation
 sonar.projectKey=AcademySoftwareFoundation_aswf-docker
 sonar.sources=.
-sonar.exclusions=packages/conan/recipes
+sonar.exclusions=packages/conan/recipes/**
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.pylint.reportPath=test-pylint-results.xml
 sonar.python.xunit.reportPath=test-pytest-results.xml


### PR DESCRIPTION
We want to minimize changes to Conan recipes from Conan Center Index, so we don't want to fill our SonarCloud analysis with issues related to those recipes.

Also update Python module requests to latest 2.32.5