### PR TITLE
Fix conan quoting and update Conan to 2.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # 2026-03-14
 
 - All releases
+  - Conan 2.18.1 to 2.26.2
   - [Replace Pipenv with uv](https://github.com/AcademySoftwareFoundation/aswf-docker/issues/269) for Python dependency management; use `uv sync --all-extras` and `uv run` (see `python/README.md`). Lockfile is `uv.lock`; dependencies are in `pyproject.toml` [project].
   - Update GitHub action versions for [NodeJS 24](https://github.com/AcademySoftwareFoundation/aswf-docker/issues/350)
   - Update some Python dependencies

--- a/ci-baseos-gl-conan/README.md
+++ b/ci-baseos-gl-conan/README.md
@@ -27,7 +27,7 @@ Contains:
 * dts-11
 * sonar-8.0.1.6346
 * cmake-3.31.7
-* conan-2.18.1
+* conan-2.26.2
 * yq-4.45.2
 
 ## [aswf/ci-baseos-gl-conan:5.5](https://hub.docker.com/r/aswf/ci-baseos-gl-conan/tags?page=1&name=5.5)
@@ -40,7 +40,7 @@ Contains:
 * dts-11
 * sonar-8.0.1.6346
 * cmake-3.31.7
-* conan-2.18.1
+* conan-2.26.2
 * yq-4.45.2
 
 ## [aswf/ci-baseos-gl-conan:6.3](https://hub.docker.com/r/aswf/ci-baseos-gl-conan/tags?page=1&name=6.3)
@@ -53,6 +53,6 @@ Contains:
 * dts-14
 * sonar-8.0.1.6346
 * cmake-4.0.2
-* conan-2.18.1
+* conan-2.26.2
 * yq-4.45.4
 

--- a/ci-common/README.md
+++ b/ci-common/README.md
@@ -185,7 +185,7 @@ Contains:
 * ccache-4.9.1
 * dts-11
 * sonar-8.0.1.6346
-* conan-2.18.1
+* conan-2.26.2
 * yq-4.45.2
 
 ## [aswf/ci-common:4-clang17.6](https://hub.docker.com/r/aswf/ci-common/tags?page=1&name=4-clang17.6)
@@ -200,7 +200,7 @@ Contains:
 * ccache-4.9.1
 * dts-11
 * sonar-8.0.1.6346
-* conan-2.18.1
+* conan-2.26.2
 * yq-4.45.2
 
 ## [aswf/ci-common:5-clang18.5](https://hub.docker.com/r/aswf/ci-common/tags?page=1&name=5-clang18.5)
@@ -215,7 +215,7 @@ Contains:
 * ccache-4.9.1
 * dts-11
 * sonar-8.0.1.6346
-* conan-2.18.1
+* conan-2.26.2
 * yq-4.45.2
 
 ## [aswf/ci-common:5-clang19.5](https://hub.docker.com/r/aswf/ci-common/tags?page=1&name=5-clang19.5)
@@ -230,7 +230,7 @@ Contains:
 * ccache-4.9.1
 * dts-11
 * sonar-8.0.1.6346
-* conan-2.18.1
+* conan-2.26.2
 * yq-4.45.2
 
 ## [aswf/ci-common:6-clang19.3](https://hub.docker.com/r/aswf/ci-common/tags?page=1&name=6-clang19.3)
@@ -245,7 +245,7 @@ Contains:
 * ccache-4.11.3
 * dts-14
 * sonar-8.0.1.6346
-* conan-2.18.1
+* conan-2.26.2
 * yq-4.45.4
 
 ## [aswf/ci-common:6-clang20.3](https://hub.docker.com/r/aswf/ci-common/tags?page=1&name=6-clang20.3)
@@ -260,6 +260,6 @@ Contains:
 * ccache-4.11.3
 * dts-14
 * sonar-8.0.1.6346
-* conan-2.18.1
+* conan-2.26.2
 * yq-4.45.4
 

--- a/packages/common/Dockerfile
+++ b/packages/common/Dockerfile
@@ -137,14 +137,14 @@ RUN --mount=type=cache,target=${ASWF_CONAN_HOME}/d \
     --mount=type=bind,rw,target=${ASWF_CONAN_HOME}/.conan2,source=packages/conan/settings \
     --mount=type=bind,rw,target=${ASWF_CONAN_HOME}/recipes,source=packages/conan/recipes \
     conan create \
-      "${ASWF_CONAN_BUILD_MISSING}" \
-      "${ASWF_CONAN_NO_REMOTE}" \
+      ${ASWF_CONAN_BUILD_MISSING} \
+      ${ASWF_CONAN_NO_REMOTE} \
       --profile:all "${ASWF_CONAN_HOME}"/.conan2/profiles_"${ASWF_PKG_ORG}"/"${ASWF_CONAN_CHANNEL}" \
       --name "${ASWF_PKG_NAME}" \
       --version "${ASWF_PKG_VERSION}" \
       --user "${ASWF_PKG_ORG}" \
       --channel "${ASWF_CONAN_CHANNEL}" \
-      "${ASWF_PKG_DIR}"/$(if [ -f "${ASWF_PKG_YML}" ] ; then yq '.versions["'"${ASWF_PKG_VERSION}"'"].folder' "${ASWF_PKG_YML}" ; fi)
+      "${ASWF_PKG_DIR}"/$(if [[ -f "${ASWF_PKG_YML}" ]] ; then yq '.versions["'"${ASWF_PKG_VERSION}"'"].folder' "${ASWF_PKG_YML}" ; fi)
 
 # Upload build to repository if called for
 RUN --mount=type=cache,target=${ASWF_CONAN_HOME}/d \

--- a/python/aswfdocker/data/versions.yaml
+++ b/python/aswfdocker/data/versions.yaml
@@ -149,7 +149,7 @@ versions:
     package_versions:
       ASWF_DTS_VERSION: "11"
       ASWF_DTS_PREFIX: "gcc-toolset"
-      ASWF_CONAN_VERSION: "2.18.1"
+      ASWF_CONAN_VERSION: "2.26.2"
       ASWF_CONAN_PYTHON_VERSION: "3.11.11"
       ASWF_CUDA_VERSION: "12.6.3"
       ASWF_OPTIX_VERSION: "8.0.0"
@@ -184,7 +184,7 @@ versions:
     package_versions:
       ASWF_DTS_VERSION: "11"
       ASWF_DTS_PREFIX: "gcc-toolset"
-      ASWF_CONAN_VERSION: "2.18.1"
+      ASWF_CONAN_VERSION: "2.26.2"
       ASWF_CONAN_PYTHON_VERSION: "3.11.11"
       ASWF_CUDA_VERSION: "12.6.3"
       ASWF_OPTIX_VERSION: "8.0.0"
@@ -220,7 +220,7 @@ versions:
     package_versions:
       ASWF_DTS_VERSION: "14"
       ASWF_DTS_PREFIX: "gcc-toolset"
-      ASWF_CONAN_VERSION: "2.18.1"
+      ASWF_CONAN_VERSION: "2.26.2"
       ASWF_CONAN_PYTHON_VERSION: "3.13.3"
       ASWF_CUDA_VERSION: "12.9.1"
       ASWF_OPTIX_VERSION: "8.0.0"


### PR DESCRIPTION
- Update Conan build version to 2.26.2 to match aswfdocker version.
- Fix quoting in packages/conan/Dockerfile to avoid passing empty strings to `conan create` command line.