### PR TITLE
Fix SonarCloud/pylint warnings

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -380,10 +380,6 @@ contextmanager-decorators=contextlib.contextmanager
 # expressions are accepted.
 generated-members=
 
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
-
 # Tells whether to warn about missing members when the owner of the attribute
 # is inferred to be None.
 ignore-none=yes

--- a/python/aswfdocker/builder.py
+++ b/python/aswfdocker/builder.py
@@ -43,9 +43,7 @@ class Builder:
             version_info = self.index.version_info(major_version)
             if self.group_info.type == constants.ImageType.PACKAGE:
                 image_base = image.replace("ci-package-", "")
-                group = self.index.get_group_from_image(
-                    self.group_info.type, image_base
-                )
+                self.index.get_group_from_image(self.group_info.type, image_base)
                 if version in versions_to_bake:
                     # Only one version per image needed
                     continue

--- a/python/aswfdocker/cli/aswfdocker.py
+++ b/python/aswfdocker/cli/aswfdocker.py
@@ -244,7 +244,7 @@ def build(
     help="Version of the package to migrate (all versions are migrated by default)",
 )
 @click.option("--dry-run", "-d", is_flag=True)
-def migrate(from_org, to_org, package, version, dry_run):
+def migrate(**kwargs):
     pass
 
 
@@ -289,7 +289,7 @@ def getdockerpush(build_info):
     help="Package version to download",
 )
 @pass_build_info
-def download(build_info, docker_org, package, version):
+def download(*_args, **_kwargs):
     pass
 
 

--- a/python/aswfdocker/tests/test_utils.py
+++ b/python/aswfdocker/tests/test_utils.py
@@ -6,8 +6,6 @@ Tests for the utility commands
 
 import unittest
 import logging
-import tempfile
-import os
 
 from click.testing import CliRunner
 

--- a/python/aswfdocker/utils.py
+++ b/python/aswfdocker/utils.py
@@ -3,7 +3,6 @@
 """
 Utility functions
 """
-import os
 import re
 import subprocess
 import datetime


### PR DESCRIPTION
Remove unused imports (os in utils.py, tempfile/os in test_utils.py), unused variable assignment in builder.py, unused arguments in deprecated CLI stubs, and deprecated ignore-mixin-members pylintrc option.

Closes #377