### PR TITLE
PySide 5 looks for Python includes inside Python build cache

### DIFF
--- a/packages/conan/recipes/pyside/conandata.yml
+++ b/packages/conan/recipes/pyside/conandata.yml
@@ -37,6 +37,9 @@ patches:
       base_path: "pyside_src"
     - patch_file: "patches/pyside_pysidesignal.diff"
       base_path: "pyside_src"
+  "5.15.18":
+    - patch_file: "patches/python_include_dir-5.15.18.diff"
+      base_path: "pyside_src"
   "5.15.9":
     - patch_file: "patches/shiboken_numpy_1_23.diff"
       base_path: "source_subfolder"

--- a/packages/conan/recipes/pyside/patches/python_include_dir-5.15.18.diff
+++ b/packages/conan/recipes/pyside/patches/python_include_dir-5.15.18.diff
@@ -1,0 +1,16 @@
+--- a/build_scripts/main.py
++++ b/build_scripts/main.py
+@@ -534,6 +534,13 @@
+         if not py_prefix or not os.path.exists(py_prefix):
+             py_prefix = sys.prefix
+         self.py_prefix = py_prefix
++        # ASWF: with a non-relocatable Python Conan package, INCLUDEPY
++        # returns a path inside the build cache that is invalid on a
++        # different machine. Fall back to deriving the include dir from
++        # py_prefix, which already has the correct relocatable fallback.
++        if not py_include_dir or not os.path.exists(py_include_dir):
++            py_include_dir = os.path.join(py_prefix, "include",
++                                          f"python{py_version}")
+         if sys.platform == "win32":
+             py_scripts_dir = os.path.join(py_prefix, "Scripts")
+         else:


### PR DESCRIPTION
PySide 5 is looking at the INCLUDEPY configuration variable for the location of the Python includes, but in the cpython package that points to an invalid Conan build cache location. Instead derive it from the cpython package installation path.