### PR TITLE
Fixes for 2023.3 / 2024.7 / 2025.6 / 2026.4 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+# 2026-05-16
+
+Fixes for 2023.3 / 2024.7 / 2025.6 / 2026.4 releases
+
+- All releases
+  - Avoid lensfun default lens library path pointing to internal Conan build cache (used by rawtoaces)
+
+- 2023.3 / 2024.7
+  - Get rid of Conan internal path in OIIO CMake files, breaks clients of OIIO
+
+- 2023.3 / 2024.7 / 2025.6
+  - Update rawtoaces version to 2.1.0 to bring current set of dependencies into all ci-rawtoaces images
+
+
 # 2026-05-03
 
 2023.3 / 2024.7 / 2025.6 / 2026.4 releases. 2023 update for Conan 2.

--- a/ci-rawtoaces/README.md
+++ b/ci-rawtoaces/README.md
@@ -21,21 +21,21 @@ Warning: this image does *not* contain rawtoaces itself as it is used to *build*
 ## [aswf/ci-rawtoaces:2023.3](https://hub.docker.com/r/aswf/ci-rawtoaces/tags?page=1&name=2023.3)
 
 Contains:
-* rawtoaces-1.1.0
+* rawtoaces-2.1.0
 * numpy-1.23.5
 * vfxplatform-2023
 
 ## [aswf/ci-rawtoaces:2024.7](https://hub.docker.com/r/aswf/ci-rawtoaces/tags?page=1&name=2024.7)
 
 Contains:
-* rawtoaces-1.1.0
+* rawtoaces-2.1.0
 * numpy-1.24.3
 * vfxplatform-2024
 
 ## [aswf/ci-rawtoaces:2025.6](https://hub.docker.com/r/aswf/ci-rawtoaces/tags?page=1&name=2025.6)
 
 Contains:
-* rawtoaces-1.1.0
+* rawtoaces-2.1.0
 * numpy-1.26.4
 * vfxplatform-2025
 

--- a/ci-vfxall/README.md
+++ b/ci-vfxall/README.md
@@ -298,7 +298,7 @@ Contains:
 * openvdb-10.1.0
 * materialx-1.38.7
 * osl-1.12.14.0
-* rawtoaces-1.1.0
+* rawtoaces-2.1.0
 * numpy-1.23.5
 * vfxplatform-2023
 
@@ -325,7 +325,7 @@ Contains:
 * openvdb-10.1.0
 * materialx-1.38.7
 * osl-1.12.14.0
-* rawtoaces-1.1.0
+* rawtoaces-2.1.0
 * numpy-1.23.5
 * vfxplatform-2023
 
@@ -352,7 +352,7 @@ Contains:
 * openvdb-11.0.0
 * materialx-1.39.1
 * osl-1.13.11.0
-* rawtoaces-1.1.0
+* rawtoaces-2.1.0
 * numpy-1.24.3
 * vfxplatform-2024
 
@@ -379,7 +379,7 @@ Contains:
 * openvdb-11.0.0
 * materialx-1.39.1
 * osl-1.13.11.0
-* rawtoaces-1.1.0
+* rawtoaces-2.1.0
 * numpy-1.24.3
 * vfxplatform-2024
 
@@ -406,7 +406,7 @@ Contains:
 * openvdb-12.1.1
 * materialx-1.39.3
 * osl-1.14.9.0
-* rawtoaces-1.1.0
+* rawtoaces-2.1.0
 * numpy-1.26.4
 * vfxplatform-2025
 
@@ -433,7 +433,7 @@ Contains:
 * openvdb-12.1.1
 * materialx-1.39.3
 * osl-1.14.9.0
-* rawtoaces-1.1.0
+* rawtoaces-2.1.0
 * numpy-1.26.4
 * vfxplatform-2025
 

--- a/packages/conan/recipes/lensfun/conandata.yml
+++ b/packages/conan/recipes/lensfun/conandata.yml
@@ -11,3 +11,5 @@ patches:
   "0.3.4":
     - patch_file: "patches/0.3.4-0001-cmake-minimum-version-3.5.patch"
       patch_description: "CMake 4 compatibility."
+    - patch_file: "patches/0.3.4-0002-database-conan-cache.patch"
+      patch_description: "Don't look for lens database in Conan cache"

--- a/packages/conan/recipes/lensfun/patches/0.3.4-0002-database-conan-cache.patch
+++ b/packages/conan/recipes/lensfun/patches/0.3.4-0002-database-conan-cache.patch
@@ -1,0 +1,11 @@
+--- include/lensfun/config.h.in.cmake
++++ include/lensfun/config.h.in.cmake
+@@ -18,7 +18,7 @@
+ #ifndef PLATFORM_WINDOWS
+ //fix path to data works only on *nix systems
+ //on windows that data dir is relocatable
+-#define CONF_DATADIR "${CMAKE_INSTALL_FULL_DATAROOTDIR}/lensfun"
++#define CONF_DATADIR "/usr/local/share/lensfun"
+ #define SYSTEM_DB_UPDATE_PATH "/${CMAKE_INSTALL_LOCALSTATEDIR}/lib/lensfun-updates"
+ #else
+ #define CONF_DATADIR "${LENSFUN_WINDOWS_DATADIR}"

--- a/packages/conan/recipes/openimageio/conanfile.py
+++ b/packages/conan/recipes/openimageio/conanfile.py
@@ -271,6 +271,7 @@ class OpenImageIOConan(ConanFile):
 
         if Version(self.version) < "2.6":
           tc.variables["CMAKE_CXX_STANDARD"] = self.settings.compiler.cppstd # ASWF: older OIIO versions need to be told compiler version
+          tc.cache_variables["OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY"] = "PRIVATE"  # ASWF: don't expose OpenEXR dependency, leaks Conan internal paths
 
         if self.settings.os == "Linux":
             # Workaround for: https://github.com/conan-io/conan/issues/13560
@@ -298,8 +299,8 @@ class OpenImageIOConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(cli_args=["--trace-expand"])
-        cmake.build(cli_args=["--verbose"])
+        cmake.configure()
+        cmake.build()
 
     def package(self):
         # ASWF: license files in package subdirectory

--- a/packages/conan/recipes/rawtoaces/conanfile.py
+++ b/packages/conan/recipes/rawtoaces/conanfile.py
@@ -50,11 +50,11 @@ class RawtoacesConan(ConanFile):
     def requirements(self):
         # Conan environment overrides
         self.requires("ceres-solver/2.2.0")
-        self.requires("imath/3.1.12")
-        self.requires("boost/1.88.0")
-        # 2.0.0 drops libraw and aces_container
+        # 2.0.0 drops imath, boost, libraw, aces_container
         # adds OpenImageIO, nlohman_json and nanobind
         if Version(self.version) < 2:
+            self.requires("imath/3.1.12")
+            self.requires("boost/1.88.0")
             self.requires("libraw/0.21.4")
             self.requires("aces_container/1.0.2")
         else:

--- a/packages/conan/settings/profiles_aswf/vfx2023
+++ b/packages/conan/settings/profiles_aswf/vfx2023
@@ -97,7 +97,7 @@ pyside/*: pyside/5.15.18@aswf/vfx2023
 pystring/*: pystring/1.1.4@aswf/vfx2023
 qt/*: qt/5.15.18@aswf/vfx2023
 rapidjson/*: rapidjson/cci.20250205@aswf/vfx2023
-rawtoaces/*: rawtoaces/1.1.0@aswf/vfx2023
+rawtoaces/*: rawtoaces/2.1.0@aswf/vfx2023
 snappy/*: snappy/1.1.10@aswf/vfx2023
 spdlog/*: spdlog/1.15.3@aswf/vfx2023
 sqlite3/*: sqlite3/system@aswf/vfx2023

--- a/packages/conan/settings/profiles_aswf/vfx2024
+++ b/packages/conan/settings/profiles_aswf/vfx2024
@@ -97,7 +97,7 @@ pyside/*: pyside/6.5.6@aswf/vfx2024
 pystring/*: pystring/1.1.4@aswf/vfx2024
 qt/*: qt/6.5.6@aswf/vfx2024
 rapidjson/*: rapidjson/cci.20250205@aswf/vfx2024
-rawtoaces/*: rawtoaces/1.1.0@aswf/vfx2024
+rawtoaces/*: rawtoaces/2.1.0@aswf/vfx2024
 snappy/*: snappy/1.1.10@aswf/vfx2024
 spdlog/*: spdlog/1.15.3@aswf/vfx2024
 sqlite3/*: sqlite3/system@aswf/vfx2024

--- a/packages/conan/settings/profiles_aswf/vfx2025
+++ b/packages/conan/settings/profiles_aswf/vfx2025
@@ -97,7 +97,7 @@ pyside/*: pyside/6.5.6@aswf/vfx2025
 pystring/*: pystring/1.1.4@aswf/vfx2025
 qt/*: qt/6.5.6@aswf/vfx2025
 rapidjson/*: rapidjson/cci.20250205@aswf/vfx2025
-rawtoaces/*: rawtoaces/1.1.0@aswf/vfx2025
+rawtoaces/*: rawtoaces/2.1.0@aswf/vfx2025
 snappy/*: snappy/1.1.10@aswf/vfx2025
 spdlog/*: spdlog/1.15.3@aswf/vfx2025
 sqlite3/*: sqlite3/system@aswf/vfx2025

--- a/packages/conan/settings/profiles_aswftesting/vfx2023
+++ b/packages/conan/settings/profiles_aswftesting/vfx2023
@@ -97,7 +97,7 @@ pyside/*: pyside/5.15.18@aswftesting/vfx2023
 pystring/*: pystring/1.1.4@aswftesting/vfx2023
 qt/*: qt/5.15.18@aswftesting/vfx2023
 rapidjson/*: rapidjson/cci.20250205@aswftesting/vfx2023
-rawtoaces/*: rawtoaces/1.1.0@aswftesting/vfx2023
+rawtoaces/*: rawtoaces/2.1.0@aswftesting/vfx2023
 snappy/*: snappy/1.1.10@aswftesting/vfx2023
 spdlog/*: spdlog/1.15.3@aswftesting/vfx2023
 sqlite3/*: sqlite3/system@aswftesting/vfx2023

--- a/packages/conan/settings/profiles_aswftesting/vfx2024
+++ b/packages/conan/settings/profiles_aswftesting/vfx2024
@@ -97,7 +97,7 @@ pyside/*: pyside/6.5.6@aswftesting/vfx2024
 pystring/*: pystring/1.1.4@aswftesting/vfx2024
 qt/*: qt/6.5.6@aswftesting/vfx2024
 rapidjson/*: rapidjson/cci.20250205@aswftesting/vfx2024
-rawtoaces/*: rawtoaces/1.1.0@aswftesting/vfx2024
+rawtoaces/*: rawtoaces/2.1.0@aswftesting/vfx2024
 snappy/*: snappy/1.1.10@aswftesting/vfx2024
 spdlog/*: spdlog/1.15.3@aswftesting/vfx2024
 sqlite3/*: sqlite3/system@aswftesting/vfx2024

--- a/packages/conan/settings/profiles_aswftesting/vfx2025
+++ b/packages/conan/settings/profiles_aswftesting/vfx2025
@@ -97,7 +97,7 @@ pyside/*: pyside/6.5.6@aswftesting/vfx2025
 pystring/*: pystring/1.1.4@aswftesting/vfx2025
 qt/*: qt/6.5.6@aswftesting/vfx2025
 rapidjson/*: rapidjson/cci.20250205@aswftesting/vfx2025
-rawtoaces/*: rawtoaces/1.1.0@aswftesting/vfx2025
+rawtoaces/*: rawtoaces/2.1.0@aswftesting/vfx2025
 snappy/*: snappy/1.1.10@aswftesting/vfx2025
 spdlog/*: spdlog/1.15.3@aswftesting/vfx2025
 sqlite3/*: sqlite3/system@aswftesting/vfx2025

--- a/python/aswfdocker/data/versions.yaml
+++ b/python/aswfdocker/data/versions.yaml
@@ -589,7 +589,7 @@ versions:
       ASWF_OPENVDB_VERSION: "10.1.0"
       ASWF_OSL_VERSION: "1.12.14.0"
       ASWF_OPENTIMELINEIO_VERSION: "0.15"
-      ASWF_RAWTOACES_VERSION: "1.1.0"
+      ASWF_RAWTOACES_VERSION: "2.1.0"
   "2023-clang14":
     parent_versions: ["3", "3-clang14", "2023"]
     major_version: "2023"
@@ -726,7 +726,7 @@ versions:
       ASWF_OPENVDB_VERSION: "11.0.0"
       ASWF_OSL_VERSION: "1.13.11.0"
       ASWF_OPENTIMELINEIO_VERSION: "0.17.0"
-      ASWF_RAWTOACES_VERSION: "1.1.0"
+      ASWF_RAWTOACES_VERSION: "2.1.0"
   "2024-clang16":
     parent_versions: ["4", "4-clang16", "2024"]
     major_version: "2024"
@@ -863,7 +863,7 @@ versions:
       ASWF_OPENVDB_VERSION: "12.1.1"
       ASWF_OSL_VERSION: "1.14.9.0"
       ASWF_OPENTIMELINEIO_VERSION: "0.17.0"
-      ASWF_RAWTOACES_VERSION: "1.1.0" 
+      ASWF_RAWTOACES_VERSION: "2.1.0" 
   "2025-clang18":
     parent_versions: ["5", "5-clang18", "2025"]
     major_version: "2025"


### PR DESCRIPTION
- All releases
  - Avoid lensfun default lens library path pointing to internal Conan build cache (used by rawtoaces)

- 2023.3 / 2024.7
  - Get rid of Conan internal path in OIIO CMake files, breaks clients of OIIO

- 2023.3 / 2024.7 / 2025.6
  - Update rawtoaces version to 2.1.0 to bring current set of dependencies into all ci-rawtoaces images