### PR TITLE
Update to UV 0.11.8

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -54,7 +54,7 @@ jobs:
         enable-cache: auto
 
     - name: Set up Python
-      run: uv python install
+      run: uv python install 3.10
 
     - name: Install aswfdocker and dependencies
       run: uv sync --frozen

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -48,18 +48,16 @@ jobs:
       env:
         BUILDKIT_STEP_LOG_MAX_SIZE: 10485760
 
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "3.9"
-
     - name: Install uv
-      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: auto
 
+    - name: Set up Python
+      run: uv python install
+
     - name: Install aswfdocker and dependencies
-      run: uv sync
+      run: uv sync --frozen
 
     - name: Free up disk space
       run: |

--- a/.github/workflows/python-sonar.yml
+++ b/.github/workflows/python-sonar.yml
@@ -14,18 +14,17 @@ jobs:
       with:
         # Disabling shallow clones is recommended for improving the relevancy of reporting
         fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "3.10"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: auto
 
+    - name: Set up Python
+      run: uv python install
+
     - name: Install aswfdocker and dev dependencies
-      run: uv sync --all-extras
+      run: uv sync --all-extras --frozen
 
     # mypy static type checks with junit XML report
     - name: Run mypy

--- a/.github/workflows/python-sonar.yml
+++ b/.github/workflows/python-sonar.yml
@@ -21,7 +21,7 @@ jobs:
         enable-cache: auto
 
     - name: Set up Python
-      run: uv python install
+      run: uv python install 3.10
 
     - name: Install aswfdocker and dev dependencies
       run: uv sync --all-extras --frozen

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,7 +25,7 @@ jobs:
         enable-cache: auto
 
     - name: Set up Python
-      run: uv python install
+      run: uv python install 3.10
 
     - name: Install aswfdocker and dev dependencies
       run: uv sync --all-extras --frozen

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,18 +19,16 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "3.10"
-
     - name: Install uv
-      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: auto
 
+    - name: Set up Python
+      run: uv python install
+
     - name: Install aswfdocker and dev dependencies
-      run: uv sync --all-extras
+      run: uv sync --all-extras --frozen
 
     - name: Run all pre-commit tests
       run: uv run pre-commit run --all-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,16 @@ jobs:
       env:
         BUILDKIT_STEP_LOG_MAX_SIZE: 10485760
 
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "3.9"
-
     - name: Install uv
-      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: auto
 
+    - name: Set up Python
+      run: uv python install
+
     - name: Install aswfdocker and dependencies
-      run: uv sync
+      run: uv sync --frozen
 
     - name: Login to DockerHub
       if: ${{ !contains(github.ref, '/ci-package') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         enable-cache: auto
 
     - name: Set up Python
-      run: uv python install
+      run: uv python install 3.10 3.10 3.10
 
     - name: Install aswfdocker and dependencies
       run: uv sync --frozen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ packages = { find = { where = ["python"] } }
 aswfdocker = ["data/*.yaml", "data/*.jinja2"]
 
 [tool.uv]
-required-version = "0.10.10"
+required-version = "0.11.8"
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
Update to UV 0.11.8, hopefully allows Dependabot to track our Python dependencies.

Update to current 8.1.0 setup-uv action.

Use uv to install required Python 3.10 instead of setup-python action.
