### PR TITLE
libmicrohttpd vs zlib dependency

### DIFF
--- a/python/aswfdocker/data/versions.yaml
+++ b/python/aswfdocker/data/versions.yaml
@@ -2411,7 +2411,6 @@ groups:
         - libcgroup
         - libdeflate
         - libiconv
-        - libmicrohttpd
         - libxcrypt
         - lua
         - lz4
@@ -2434,6 +2433,7 @@ groups:
         - freetype
         - glew
         - glfw
+        - libmicrohttpd
         - log4cplus
         - minizip-ng
       base1-3:


### PR DESCRIPTION
libmicrohttpd depends on zlib, needs to be moved to next build strata aka base1-2