### PR TITLE
ispc and OIDN now in ci-moonray images

### DIFF
--- a/packages/conan/recipes/ispc/conanfile.py
+++ b/packages/conan/recipes/ispc/conanfile.py
@@ -6,6 +6,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import copy, get
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
 required_conan_version = ">=2.1"
 
@@ -21,7 +22,10 @@ class IspcConan(ConanFile):
     homepage = "https://ispc.github.io/"
     topics = ("ispc", "compiler", "simd", "spmd")
     package_type = "application"
-    settings = "os", "arch"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def validate(self):
         if self.settings.os not in ["Linux", "Macos", "Windows"]:

--- a/packages/conan/recipes/moonray/conanfile.py
+++ b/packages/conan/recipes/moonray/conanfile.py
@@ -55,5 +55,8 @@ class MoonrayConan(ConanFile):
         self.requires("openimagedenoise/2.3.3")  # mcrt_denoise
         self.requires("random123/1.14.0")     # stochastic sampling
 
+        # ---- Build Tools ----
+        self.requires("ispc/[>=1.21.0]")      # should be a tool_requires() but we need it in the ci-moonray image
+
     def package_id(self):
         self.info.clear()

--- a/packages/conan/recipes/openimagedenoise/conanfile.py
+++ b/packages/conan/recipes/openimagedenoise/conanfile.py
@@ -6,6 +6,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import copy, get
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
 required_conan_version = ">=2.1"
 
@@ -21,7 +22,10 @@ class OpenImageDenoiseConan(ConanFile):
     homepage = "https://www.openimagedenoise.org/"
     topics = ("denoising", "rendering", "deep-learning", "intel")
     package_type = "shared-library"
-    settings = "os", "arch"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("onetbb/2023.0.0")


### PR DESCRIPTION
The ispc and openimagedenoise recipes currently download and wrap pre-built binaries, adapt the package structure to match the built from source packages so they can get correctly installed when building the ci-openmoonray container image.

Also make sure the moonray recipe references ispc as a requires() rather than a tool_requires(), otherwise ispc won't get included in the image.